### PR TITLE
fixes diff drive lockup?

### DIFF
--- a/launch/navigation.launch
+++ b/launch/navigation.launch
@@ -4,11 +4,11 @@
   <param name="robot_description" command="xacro $(find mrover)/rover_description/rover.xacro" />
   <arg name="rvizconfig" default="$(find mrover)/config/rviz/navigation.rviz" />
   <arg name="gazebo_config_path" default="$(find mrover)/config/gazebo" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" />
 
   <node if="$(arg gui)" name="joint_state_publisher" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
   <node unless="$(arg gui)" name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" />
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <env name="GAZEBO_MODEL_PATH" value="$(arg gazebo_config_path)/env_description" />
@@ -39,6 +39,7 @@
     ===========
   -->
   <!-- This publishes the transforms of the course waypoints -->
+  <node name="nav" pkg="mrover" type="navigation.py" />
 
   <!--
     ============

--- a/src/gazebo/differential_drive_6w.cpp
+++ b/src/gazebo/differential_drive_6w.cpp
@@ -145,7 +145,8 @@ namespace gazebo {
         sub_ = rosnode_->subscribe(so);
         pub_ = rosnode_->advertise<nav_msgs::Odometry>("odom", 1);
 
-        callback_queue_thread_ = boost::thread(boost::bind(&DiffDrivePlugin6W::QueueThread, this));
+        // TODO(amg): disabled due to weirdness where the thread would die and callbacks stop
+        //callback_queue_thread_ = boost::thread(boost::bind(&DiffDrivePlugin6W::QueueThread, this));
 
         Reset();
 
@@ -181,6 +182,11 @@ namespace gazebo {
 
     // Update the controller
     void DiffDrivePlugin6W::Update() {
+
+        // TODO(amg): This is probably bad...
+        static const double timeout = 0.01;
+        queue_.callAvailable(ros::WallDuration(timeout));
+
         // TODO: Step should be in a parameter of this function
         double d1, d2;
         double dr, da;


### PR DESCRIPTION
## Summary
Addresses Issue: #53 

This is potentially a fix to #53. The underlying non-determinism involved makes it hard for me to be certain though so everyone should keep an eye out for the next couple weeks. I tested it about 10 times with this fix and didn't see the issue occur, whereas without I would have the problem every 3-4 times.

Here's what I did to debug this:
- Compiled the libdiffdrive plugin as a Debug target in the CMakeLists.txt with `set(CMAKE_BUILD_TYPE Debug)`
- Launched the navigation launchfile and ran the debug course publisher 
- Used gdb to attach to the pid of the `gzserver` instance from the directory of the shared object `devel/.private/mrover/lib` to load the symbols

I observed the following when the problem occurred:
- The node is still connected to the ROS network. Its publisher to `/odom` works fine. Doesn't seem like a network issue 
- The `/cmd_vel` subscriber is not called, moreover, the thread that is responsible for calling subscriber callbacks from the callback queue is not running indicating that it crashed, since the main thread `Update` ticks are still occurring so the object hasn't been destructed

I initially thought that maybe some exception was occurring in handling the callback that caused the callback thread to crash, however if that was the case, the exception does not seem to be occurring when the same callback handling logic occurs in the main thread. Seems like maybe ROS does not play nicely with handling subscriber callbacks in a separate thread? 

Further debugging could probably be done here to get to the root cause if anyone cares. Launch GDB within the launch file with the `gzserver` node so breakpoints can get placed before the thread dies and we can look at the stacktrace on exception.  See [this](http://wiki.ros.org/roslaunch/Tutorials/Roslaunch%20Nodes%20in%20Valgrind%20or%20GDB) for reference. 

For the time being I went ahead and changed this into a single-threaded application where the callback processing happens in the plugin's main `Update()`. 

### Did you add documentation to the wiki?
No - this is a bug fix that does not change any core logic

## How was this code tested? 
This code was tested in sim by repeatedly running `roslaunch mrover navigation.launch` followed by `rosrun mrover debug_course_publisher.py` and seeing if the robot moved or not. 

### Did you test this in sim? 
Yes. 

### Did you test this on the rover?
Not applicable, simulation-only bug fix

### Did you add unit tests? 
No, this is very hard to unit test