### PR TITLE
Add cache to perception

### DIFF
--- a/src/perception/aruco_detect.hpp
+++ b/src/perception/aruco_detect.hpp
@@ -30,6 +30,8 @@ constexpr char const* ROVER_FRAME = "base_link";
  */
 struct ImmediateFiducial {
     int id = -1;
+    uint64_t missCount = 0;
+    uint64_t hitCount = 0;
     cv::Point2f imageCenter{};
     std::optional<SE3> fidInCam;
 };

--- a/src/perception/aruco_processing.cpp
+++ b/src/perception/aruco_processing.cpp
@@ -44,7 +44,7 @@ void FiducialsNode::imageCallback(sensor_msgs::ImageConstPtr const& msg) {
         }
 
         // Add readings to the persistent representations of the fiducials
-        for (auto [id, immediateFid]: mImmediateFiducials) {
+        for (auto& [id, immediateFid]: mImmediateFiducials) {
             PersistentFiducial& fid = mPersistentFiducials[id];
             if (!immediateFid.fidInCam.has_value()) continue; // This is set if the point cloud had a valid reading for this fiducial
 
@@ -63,7 +63,7 @@ void FiducialsNode::imageCallback(sensor_msgs::ImageConstPtr const& msg) {
         }
 
         // Send all transforms of persistent fiducials
-        for (auto [id, fid]: mPersistentFiducials) {
+        for (auto& [id, fid]: mPersistentFiducials) {
             if (!fid.fidInOdomX.ready()) continue; // Wait until the filters have enough readings to become meaningful
 
             SE3::pushToTfTree(mTfBroadcaster, "fiducial" + std::to_string(id), ODOM_FRAME, fid.getFidInOdom());

--- a/src/perception/aruco_processing.cpp
+++ b/src/perception/aruco_processing.cpp
@@ -27,11 +27,22 @@ void FiducialsNode::imageCallback(sensor_msgs::ImageConstPtr const& msg) {
         // Remove fiducials in the immediate buffer that are no longer in sight
         auto it = mImmediateFiducials.begin();
         while (it != mImmediateFiducials.end()) {
-            if (std::find(mIds.begin(), mIds.end(), it->first) == mIds.end()) {
-                it = mImmediateFiducials.erase(it);
+            bool isPresent = std::find(mIds.begin(), mIds.end(), it->first) != mIds.end();
+            bool doErase = false;
+
+            ImmediateFiducial& fiducial = it->second;
+            if (isPresent) {
+                fiducial.hitCount++;
             } else {
-                ++it;
+                fiducial.missCount++;
+                if (fiducial.missCount >= 5) // TODO: replace hardcode
+                    doErase = true;
             }
+
+            if (doErase)
+                it = mImmediateFiducials.erase(it);
+            else
+                ++it;
         }
 
         // Save fiducials currently on screen to the immediate buffer


### PR DESCRIPTION
## Summary
Closes #59 

Idea: Often times we have faulty detections for a frame or so. We do not want to use these readings. Add a "cache" which is not such a good word but basically filters these intermittent values out.

### Did you add documentation to the wiki?
Yes/No (If not explain why not)

## How was this code tested? 
Summarize how you tested this code. Your objective here is to prove to the reviewers that this code actually works without them having to run it themselves. It is often helpful to include screenshots, tables, graphs, and/or a short write-up of testing procedures. Results can be either from sim, the robot, or both depending on what you think is sufficient for the feature you added. 

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
