### PR TITLE
Changed wheel control interface back to [-1,1]

### DIFF
--- a/config/teleop.yaml
+++ b/config/teleop.yaml
@@ -24,6 +24,8 @@ teleop:
       multiplier: -1
     left_right:
       multiplier: -1
+    twist:
+      multiplier: 1
   xbox_mappings:
     left_js_x: 0
     left_js_y: 1

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -7,11 +7,4 @@
   <node name="gui" pkg="mrover" type="gui_run.sh" cwd="node"/>
   <!--Node for teleop control callbacks-->
   <node name="jetson_teleop" pkg="mrover" type="jetson_teleop.py"/>
-  <!--Translate joystick inputs to twist velocity values-->
-  <node name="teleop_twist_joy" pkg="teleop_twist_joy" type="teleop_node">
-    <param name="enable_button" value="-1"/>
-    <param name="enable_turbo_button" value="0"/>
-    <remap from="/joy" to="/joystick" />
-    <remap from="/cmd_vel" to="/drive_cmd_twist" />
-  </node>
 </launch>

--- a/src/teleop/gui/src/components/DriveControls.vue
+++ b/src/teleop/gui/src/components/DriveControls.vue
@@ -59,7 +59,7 @@ export default {
         for (let i = 0; i < 4; i++) {
           const gamepad = gamepads[i]
           if (gamepad) {
-            if (gamepad.id.includes('Logitech')) {
+            if (gamepad.id.includes('Xbox')) {
             
               let buttons = gamepad.buttons.map((button) =>{
                 return button.value
@@ -70,12 +70,10 @@ export default {
               let axes = gamepad.axes.map((axis) => {
                 return Math.abs(axis) <= deadzone ? 0 : axis
               })
+              
               //Invert Forward/Back Stick, forward is normally -1
               axes[this.joystick_mapping.forward_back] = this.drive_config.forward_back.multiplier * axes[this.joystick_mapping.forward_back]
               axes[this.joystick_mapping.left_right] = this.drive_config.left_right.multiplier * axes[this.joystick_mapping.left_right]
-
-              //Done so that teleop_twist_joy will always be enabled
-              buttons.unshift(1)
 
               const joystickData = {
                 axes: axes,

--- a/src/teleop/gui/src/components/DriveControls.vue
+++ b/src/teleop/gui/src/components/DriveControls.vue
@@ -13,10 +13,6 @@ let interval;
 export default {
   data () {
     return {
-      dampen: 0,
-      reverse: false,
-      drive_config: null,
-      joystick_mapping: null
     }
   },
 
@@ -26,33 +22,6 @@ export default {
   },
 
   created: function () {
-
-    var drive_control_param = new ROSLIB.Param({
-      ros : this.$ros,
-      name :  '/teleop/drive_controls'
-    });
-
-    
-    var joystick_mapping_param = new ROSLIB.Param({
-      ros : this.$ros,
-      name :  '/teleop/joystick_mappings'
-    });
-
-    drive_control_param.get((value) => {
-      if (value != null) {
-          this.drive_config = value;
-          console.log(this.drive_config.forward_back.multiplier)
-      }
-    });
-      
-    joystick_mapping_param.get((value) => {
-      if (value != null) {
-        this.joystick_mapping = value;
-        console.log(this.joystick_mapping)
-      }
-    });
-
-
     const updateRate = 0.05;
     interval = window.setInterval(() => {
         const gamepads = navigator.getGamepads()
@@ -65,15 +34,7 @@ export default {
                 return button.value
               })
 
-              //Deadzone applied to all axis
-              const deadzone = 0.05
-              let axes = gamepad.axes.map((axis) => {
-                return Math.abs(axis) <= deadzone ? 0 : axis
-              })
-              
-              //Invert Forward/Back Stick, forward is normally -1
-              axes[this.joystick_mapping.forward_back] = this.drive_config.forward_back.multiplier * axes[this.joystick_mapping.forward_back]
-              axes[this.joystick_mapping.left_right] = this.drive_config.left_right.multiplier * axes[this.joystick_mapping.left_right]
+              let axes=gamepad.axes
 
               const joystickData = {
                 axes: axes,

--- a/src/teleop/jetson/jetson_teleop.py
+++ b/src/teleop/jetson/jetson_teleop.py
@@ -2,18 +2,17 @@
 # Node for teleop-related callback functions
 
 from math import copysign
+from turtle import forward
 import typing
 from enum import IntEnum
 import rospy as ros
 from sensor_msgs.msg import Joy, JointState
-from geometry_msgs.msg import Twist
-from mrover.msg import Chassis
 
 
 def quadratic(val):
     return copysign(val**2, val)
 
-
+# If below threshold, make output zero
 def deadzone(magnitude, threshold):
     temp_mag = abs(magnitude)
     if temp_mag <= threshold:
@@ -39,25 +38,34 @@ class Drive:
         # Constants for diff drive
         self.TRACK_RADIUS = track_radius  # meter
         self.WHEEL_RADIUS = wheel_radius  # meter
-        self.drive_vel_pub = ros.Publisher("/drive_cmd_wheels", Chassis, queue_size=100)
+        self.left_wheel_pub = ros.Publisher("/drive_cmd/left_wheels", JointState, queue_size=100)
+        self.right_wheel_pub = ros.Publisher("/drive_cmd/right_wheels", JointState, queue_size=100)
 
-    # TODO: Reimplement Dampen Switch
     def teleop_drive_callback(self, msg):
+        joints: typing.Dict[str, JointState] = {}
 
-        # teleop_twist_joy angular message is maxed at 0.5 regardless of
-        # turbo mode, multiply by 2 to make range [-1,1]
-        v = msg.linear.x
-        omega = msg.angular.z * 2
+        forward_back = deadzone(msg.axes[self.joystick_mappings["forward_back"]], 0.05)
+        left_right = deadzone(
+            msg.axes[self.joystick_mappings["left_right"]] + msg.axes[self.joystick_mappings["twist"]], 0.05
+        )
 
-        # Transform into L & R wheel angular velocities using diff drive kinematics
-        omega_l = (v - omega * self.TRACK_RADIUS / 2.0) / self.WHEEL_RADIUS
-        omega_r = (v + omega * self.TRACK_RADIUS / 2.0) / self.WHEEL_RADIUS
+        # Super small deadzone so we can safely e-stop with dampen switch
+        dampen = deadzone(msg.axes[self.joystick_mappings["dampen"]], 0.01)
 
-        command = Chassis()
-        command.omega_l = omega_l
-        command.omega_r = omega_r
+        left = dampen * (forward_back + left_right)
+        right = dampen * (forward_back - left_right)
 
-        self.drive_vel_pub.publish(command)
+        # Ensure values are [-1,1] for each side
+        if abs(left) > 1:
+            left = left / abs(left)
+        if abs(right) > 1:
+            right = right / abs(right)
+
+        create_joint_msg(joints, "left_wheels", left)
+        create_joint_msg(joints, "right_wheels", right)
+
+        self.left_wheel_pub.publish(joints["left_wheels"])
+        self.right_wheel_pub.publish(joints["right_wheels"])
 
 
 class ArmControl:
@@ -147,7 +155,7 @@ class ArmControl:
 def main():
     ros.init_node("teleop")
     xbox = ros.get_param("/teleop/xbox_mappings")
-    joystick = ros.get_param("/teleop/xbox_mappings")
+    joystick = ros.get_param("/teleop/joystick_mappings")
     ra_config = ros.get_param("/teleop/ra_controls")
     drive_config = ros.get_param("/teleop/drive_controls")
     track_radius = ros.get_param("/teleop/constants/track_radius")
@@ -158,7 +166,7 @@ def main():
         joystick_mappings=joystick, drive_config=drive_config, track_radius=track_radius, wheel_radius=wheel_radius
     )
 
-    ros.Subscriber("/drive_cmd_twist", Twist, drive.teleop_drive_callback)
+    ros.Subscriber("/joystick", Joy, drive.teleop_drive_callback)
     ros.Subscriber("/xbox/ra_control", Joy, arm.ra_control_callback)
 
     ros.spin()

--- a/src/teleop/jetson/jetson_teleop.py
+++ b/src/teleop/jetson/jetson_teleop.py
@@ -12,6 +12,7 @@ from sensor_msgs.msg import Joy, JointState
 def quadratic(val):
     return copysign(val**2, val)
 
+
 # If below threshold, make output zero
 def deadzone(magnitude, threshold):
     temp_mag = abs(magnitude)
@@ -44,9 +45,13 @@ class Drive:
     def teleop_drive_callback(self, msg):
         joints: typing.Dict[str, JointState] = {}
 
-        forward_back = deadzone(msg.axes[self.joystick_mappings["forward_back"]], 0.05)
+        forward_back = deadzone(
+            msg.axes[self.joystick_mappings["forward_back"]] * self.drive_config["forward_back"]["multiplier"], 0.05
+        )
         left_right = deadzone(
-            msg.axes[self.joystick_mappings["left_right"]] + msg.axes[self.joystick_mappings["twist"]], 0.05
+            msg.axes[self.joystick_mappings["left_right"]] * self.drive_config["left_right"]["multiplier"]
+            + msg.axes[self.joystick_mappings["twist"]] * self.drive_config["twist"]["multiplier"],
+            0.05,
         )
 
         # Super small deadzone so we can safely e-stop with dampen switch


### PR DESCRIPTION
## Summary
Solves #132 

What features did you add, bugs did you fix, etc? 
Drive code is now similar to old codebase. Twist and dampen switches should work now. Moved deadzone/multipliers to jetson_teleop


### Did you add documentation to the wiki?
No, but should probably make a full drive/arm controls page in the near future

## How was this code tested? 
Tested with my own controller, not the logitech stick, should probably test before merging.

### Did you test this in sim? 
No

### Did you test this on the rover?
No

### Did you add unit tests? 
NO
