### PR TITLE
Remove GUI install from CMakeLists, add node and yarn to install script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,11 +258,3 @@ catkin_add_nosetests(test/util/SO3_test.py)
 find_package(rostest REQUIRED)
 add_rostest(test/example/basic_integration_test.test)
 add_rostest(test/util/SE3_tf_test.test)
-
-# Base Station GUI Script to ensure proper deps
-# and node_modules up to date
-add_custom_target(
-        gui ALL
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/teleop/gui
-        COMMAND ./gui_install.sh
-        )

--- a/install.py
+++ b/install.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-BASE_APT_DEPS = ['curl', 'vim', 'zsh', 'git', 'git-lfs', 'python3-pip', 'clang-format-12']
+BASE_APT_DEPS = ['curl', 'vim', 'zsh', 'git', 'git-lfs', 'python3-pip', 'clang-format-12', 'nodejs', 'yarn']
 ROS_APT_DEPS = ['ros-noetic-desktop', 'python3-catkin-tools', 'python3-rosdep']
 
 MROVER_ROS_GIT_URL = 'https://github.com/umrover/mrover-ros.git'


### PR DESCRIPTION
## Summary
Should fix issues with infinite catkin build, my bad. Will likely add gui_install.sh back to cmake in the future with an arg for it. This PR is just to get people to be able to build again. 
Also added node and yarn install to the install.py script.

What features did you add, bugs did you fix, etc? 
Above

### Did you add documentation to the wiki?
Yes, updated GUI setup/troubleshooting page

## How was this code tested? 
N/A

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
