### PR TITLE
Remove svelte from gui package.json files to fix dependabot errors

### DIFF
--- a/src/teleop/gui/package.json
+++ b/src/teleop/gui/package.json
@@ -24,8 +24,6 @@
     "html-webpack-plugin": "^3.2.0",
     "path": "^0.12.7",
     "roslib": "^1.3.0",
-    "svelte": "^2.12.1",
-    "svelte-loader": "^2.10.1",
     "vue": "^2.5.17",
     "vue-chartjs": "^3.5.1",
     "vue-loader": "^15.4.0",

--- a/starter_project/teleop/package.json
+++ b/starter_project/teleop/package.json
@@ -24,8 +24,6 @@
     "html-webpack-plugin": "^3.2.0",
     "path": "^0.12.7",
     "roslib": "^1.3.0",
-    "svelte": "^2.12.1",
-    "svelte-loader": "^2.10.1",
     "vue": "^2.5.17",
     "vue-chartjs": "^3.5.1",
     "vue-loader": "^15.4.0",


### PR DESCRIPTION
## Summary
Closes #137 

What features did you add, bugs did you fix, etc? 
Removed Svelte, I don't know why we even had it. 

### Did you add documentation to the wiki?
No

## How was this code tested? 
I ran the gui after yarn installing with the new package.json and everything worked as intented.

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
