### PR TITLE
Added functionality to get the timestamp from the TF tree

### DIFF
--- a/src/navigation/context.py
+++ b/src/navigation/context.py
@@ -31,6 +31,9 @@ class Rover:
     def send_drive_stop(self):
         self.send_drive_command(Twist())
 
+    def get_time(self):
+        return SE3.from_se3_time(self.ctx.tf_buffer, parent_frame="map", child_frame="base_link")
+
 
 @dataclass
 class Environment:

--- a/src/navigation/context.py
+++ b/src/navigation/context.py
@@ -31,7 +31,7 @@ class Rover:
     def send_drive_stop(self):
         self.send_drive_command(Twist())
 
-    def get_time(self):
+    def get_pose_with_time(self):
         return SE3.from_se3_time(self.ctx.tf_buffer, parent_frame="map", child_frame="base_link")
 
 

--- a/src/util/SE3.py
+++ b/src/util/SE3.py
@@ -7,6 +7,8 @@ import rospy
 
 from ros_numpy import numpify
 from geometry_msgs.msg import TransformStamped, Vector3, Quaternion
+from std_msgs.msg import Time
+from typing import Tuple
 from .SO3 import SO3
 
 
@@ -62,7 +64,7 @@ class SE3:
         return result
 
     @classmethod
-    def from_se3_time(cls, tf_buffer: tf2_ros.Buffer, parent_frame: str, child_frame: str):
+    def from_se3_time(cls, tf_buffer: tf2_ros.Buffer, parent_frame: str, child_frame: str) -> Tuple[SE3, Time]:
         """
         Ask the TF tree for the time stamp of a frame and return it in a tuple with an
         SE3 that holds the transform from the parent to the child_frame
@@ -70,7 +72,6 @@ class SE3:
 
         tf_msg = tf_buffer.lookup_transform(parent_frame, child_frame, rospy.Time()).transform
         result = SE3(position=numpify(tf_msg.translation), rotation=SO3(numpify(tf_msg.rotation)))
-        rospy.logerr("Getting time")
         time_stamp = tf_buffer.lookup_transform(parent_frame, child_frame, rospy.Time()).header.stamp
         return (result, time_stamp)
 

--- a/src/util/SE3.py
+++ b/src/util/SE3.py
@@ -61,6 +61,19 @@ class SE3:
         result = SE3(position=numpify(tf_msg.translation), rotation=SO3(numpify(tf_msg.rotation)))
         return result
 
+    @classmethod
+    def from_se3_time(cls, tf_buffer: tf2_ros.Buffer, parent_frame: str, child_frame: str):
+        """
+        Ask the TF tree for the time stamp of a frame and return it in a tuple with an
+        SE3 that holds the transform from the parent to the child_frame
+        """
+
+        tf_msg = tf_buffer.lookup_transform(parent_frame, child_frame, rospy.Time()).transform
+        result = SE3(position=numpify(tf_msg.translation), rotation=SO3(numpify(tf_msg.rotation)))
+        rospy.logerr("Getting time")
+        time_stamp = tf_buffer.lookup_transform(parent_frame, child_frame, rospy.Time()).header.stamp
+        return (result, time_stamp)
+
     def publish_to_tf_tree(
         self,
         tf_broadcaster: tf2_ros.TransformBroadcaster | tf2_ros.StaticTransformBroadcaster,


### PR DESCRIPTION
## Summary
Closes #(Your issue number here)
There was no issue associated with this PR.

What features did you add, bugs did you fix, etc? 
I added a function in context.py and se3.py that returns a tuple. The first element in the tuple is an se3 representing the
transform between the parent and child frame. The second element is the timestamp of the frame

### Did you add documentation to the wiki?
No. It was just one function so I did not think there needed to be documentation in the wiki.

## How was this code tested? 
I ran the debug course in rviz and printed the timestamp obtained by the function I added using rospy.logerr()

### Did you test this in sim? 
Yes

### Did you test this on the rover?
No

### Did you add unit tests? 
No. I was primarily concerned with getting the timestamp so I was able to see this value when using rospy.logerr(). 
