### PR TITLE
Fix issues with turning sensitivity on joystick

### DIFF
--- a/config/teleop.yaml
+++ b/config/teleop.yaml
@@ -22,7 +22,7 @@ teleop:
       multiplier: 1
     left_right:
       # Can be disabled here since left_right axis sucks
-      enabled: 1
+      enabled: false
       multiplier: 1
     twist:
       multiplier: 0.7

--- a/config/teleop.yaml
+++ b/config/teleop.yaml
@@ -21,6 +21,8 @@ teleop:
     forward_back:
       multiplier: 1
     left_right:
+      # Can be disabled here since left_right axis sucks
+      enabled: 1
       multiplier: 1
     twist:
       multiplier: 0.7

--- a/src/teleop/jetson/jetson_teleop.py
+++ b/src/teleop/jetson/jetson_teleop.py
@@ -54,11 +54,17 @@ class Drive:
         # Convert from [0,1] to [0, max_wheel_speed] and apply dampen
         linear *= self.max_wheel_speed * dampen
 
-        angular = deadzone(
-            msg.axes[self.joystick_mappings["left_right"]] * self.drive_config["left_right"]["multiplier"]
-            + msg.axes[self.joystick_mappings["twist"]] * self.drive_config["twist"]["multiplier"],
-            0.05,
+        # Deadzones for each axis
+        left_right = (
+            deadzone(
+                msg.axes[self.joystick_mappings["left_right"]] * self.drive_config["left_right"]["multiplier"], 0.4
+            )
+            if self.drive_config["left_right"]["enabled"]
+            else 0
         )
+        twist = deadzone(msg.axes[self.joystick_mappings["twist"]] * self.drive_config["twist"]["multiplier"], 0.1)
+
+        angular = twist + left_right
 
         # Same as linear but for angular speed
         angular *= self.max_angular_speed * dampen


### PR DESCRIPTION
Fixes the issues that multiple people had reported with the sensitivity of the left_right axis on the joystick and allows you to disable that axis via teleop.yaml in order to turn using only the twist axis. Should make driving much better.

## Summary
Closes #(Your issue number here)

What features did you add, bugs did you fix, etc? 

### Did you add documentation to the wiki?
Yes/No (If not explain why not)

## How was this code tested? 
Tested on base station with rostopic echo and logitech joystick

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
