### PR TITLE
Don't publish invalid TFs

### DIFF
--- a/src/esw/imu_driver.py
+++ b/src/esw/imu_driver.py
@@ -46,7 +46,7 @@ def main():
             data = [float(val.strip()) for val in line.split()]
 
         except ValueError:
-            print("invalid msg format")
+            rospy.logerr("invalid msg format")
             continue
 
         # partition data into different sensors, converting calibration data from float to int
@@ -60,7 +60,7 @@ def main():
             cal_data = [int(n) for n in data[14:18]]
 
         except IndexError:
-            print("incomplete msg")
+            rospy.logerr("incomplete msg")
             continue
 
         # fill in all sensor messages, setting timestamps of each message to right now,

--- a/src/localization/gps_linearization.py
+++ b/src/localization/gps_linearization.py
@@ -42,6 +42,8 @@ class GPSLinearization:
         cartesian = np.array(
             geodetic2enu(msg.latitude, msg.longitude, msg.altitude, self.ref_lat, self.ref_lon, self.ref_alt, deg=True)
         )
+        if np.any(np.isnan(cartesian)):
+            return
 
         # ignore Z
         cartesian[2] = 0
@@ -57,6 +59,9 @@ class GPSLinearization:
         """
         # convert ROS msg quaternion to numpy array
         imu_quat = np.array([msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w])
+
+        # normalize to avoid rounding errors
+        imu_quat = imu_quat / np.linalg.norm(imu_quat)
 
         # get a quaternion to rotate about the Z axis by 90 degrees
         offset_quat = quaternion_about_axis(np.pi / 2, np.array([0, 0, 1]))


### PR DESCRIPTION
## Summary
Closes #284 

What features did you add, bugs did you fix, etc? 
Added a check so we don't publish to the TF tree if there are NaN values in GPS data, added a normalization step to the IMU quaternion so we fix invalid quaternions from the IMU caused by rounding errors.

### Did you add documentation to the wiki?
No, very minor change that doesn't affect much

## How was this code tested? 
tested in rover and it prevented publishing when GPS was indoors, tested with sim regression test.

### Did you test this in sim? 
Yes

### Did you test this on the rover?
Yes

### Did you add unit tests? 
No
