### PR TITLE
Misc: RViz path plotting, update script, remove camera feed

### DIFF
--- a/config/rviz/basestation.rviz
+++ b/config/rviz/basestation.rviz
@@ -5,7 +5,7 @@ Panels:
     Property Tree Widget:
       Expanded: ~
       Splitter Ratio: 0.5
-    Tree Height: 613
+    Tree Height: 994
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -23,7 +23,7 @@ Panels:
   - Class: rviz/Time
     Name: Time
     SyncMode: 0
-    SyncSource: ZED Camera
+    SyncSource: ""
 Preferences:
   PromptSaveOnExit: true
 Toolbars:
@@ -54,26 +54,6 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: false
-        back_left_wheel_link:
-          Value: false
-        back_right_wheel_link:
-          Value: false
-        base_link:
-          Value: true
-        camera_link:
-          Value: false
-        center_left_wheel_link:
-          Value: false
-        center_right_wheel_link:
-          Value: false
-        front_left_wheel_link:
-          Value: false
-        front_right_wheel_link:
-          Value: false
-        imu_link:
-          Value: false
-        odom:
-          Value: true
       Marker Alpha: 1
       Marker Scale: 1
       Name: TF
@@ -81,24 +61,7 @@ Visualization Manager:
       Show Axes: true
       Show Names: true
       Tree:
-        odom:
-          base_link:
-            back_left_wheel_link:
-              {}
-            back_right_wheel_link:
-              {}
-            camera_link:
-              {}
-            center_left_wheel_link:
-              {}
-            center_right_wheel_link:
-              {}
-            front_left_wheel_link:
-              {}
-            front_right_wheel_link:
-              {}
-            imu_link:
-              {}
+        {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -111,50 +74,6 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-        back_left_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        back_right_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        base_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        camera_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        center_left_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        center_right_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_left_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_right_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        imu_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Name: Rover Model
       Robot Description: robot_description
       TF Prefix: ""
@@ -216,7 +135,7 @@ Visualization Manager:
           Use rainbow: true
           Value: false
         - Class: rviz/Image
-          Enabled: true
+          Enabled: false
           Image Topic: /fiducial_images
           Max Value: 1
           Median window: 5
@@ -226,7 +145,7 @@ Visualization Manager:
           Queue Size: 2
           Transport Hint: compressed
           Unreliable: false
-          Value: true
+          Value: false
       Enabled: true
       Name: Perception
   Enabled: true
@@ -280,10 +199,10 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1172
+  Height: 1311
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd00000004000000000000015a000003edfc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006b00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000044000002fb000000eb00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000014005a00450044002000430061006d0065007200610100000346000000eb0000001600ffffff00000001000001000000035dfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003b0000035d000000b900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000041a0000003efc0100000002fb0000000800540069006d006501000000000000041a000003a200fffffffb0000000800540069006d00650100000000000004500000000000000000000002b9000003ed00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000015a00000478fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006b00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000004400000478000000eb00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000014005a00450044002000430061006d00650072006100000003b00000010c0000001600ffffff00000001000001000000035dfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003b0000035d000000b900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006a00000003efc0100000002fb0000000800540069006d00650100000000000006a0000003a200fffffffb0000000800540069006d006501000000000000045000000000000000000000053f0000047800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -292,8 +211,8 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1050
-  X: 0
-  Y: 0
+  Width: 1696
+  X: 1726
+  Y: 114
   ZED Camera:
     collapsed: false

--- a/launch/auton.launch
+++ b/launch/auton.launch
@@ -32,10 +32,10 @@
   <node name="gps_linearization" pkg="mrover" type="gps_linearization.py" output="screen" />
 
   <!-- plot the rover trajectory in rviz as it drives -->
-  <node name="hectory_trajectory_server" output="screen" pkg="hector_trajectory_server" type="hector_trajectory_server" >
+  <!-- <node name="hectory_trajectory_server" output="screen" pkg="hector_trajectory_server" type="hector_trajectory_server" >
     <param name="target_frame_name" type="string" value="map" />
     <param name="source_frame_name" type="string" value="base_link" /> 
     <param name="trajectory_update_rate" type="double" value="4" /> 
     <param name="trajectory_publish_rate" type="double" value="4" />
-  </node>
+  </node> -->
 </launch>

--- a/launch/auton.launch
+++ b/launch/auton.launch
@@ -30,4 +30,12 @@
   -->
   <rosparam command="load" file="$(find mrover)/config/localization.yaml" />
   <node name="gps_linearization" pkg="mrover" type="gps_linearization.py" output="screen" />
+
+  <!-- plot the rover trajectory in rviz as it drives -->
+  <node name="hectory_trajectory_server" output="screen" pkg="hector_trajectory_server" type="hector_trajectory_server" >
+    <param name="target_frame_name" type="string" value="map" />
+    <param name="source_frame_name" type="string" value="base_link" /> 
+    <param name="trajectory_update_rate" type="double" value="4" /> 
+    <param name="trajectory_publish_rate" type="double" value="4" />
+  </node>
 </launch>

--- a/launch/auton.launch
+++ b/launch/auton.launch
@@ -32,10 +32,10 @@
   <node name="gps_linearization" pkg="mrover" type="gps_linearization.py" output="screen" />
 
   <!-- plot the rover trajectory in rviz as it drives -->
-  <!-- <node name="hectory_trajectory_server" output="screen" pkg="hector_trajectory_server" type="hector_trajectory_server" >
+  <node name="hectory_trajectory_server" output="screen" pkg="hector_trajectory_server" type="hector_trajectory_server" >
     <param name="target_frame_name" type="string" value="map" />
     <param name="source_frame_name" type="string" value="base_link" /> 
     <param name="trajectory_update_rate" type="double" value="4" /> 
     <param name="trajectory_publish_rate" type="double" value="4" />
-  </node> -->
+  </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -70,6 +70,7 @@
   <!-- Visualization -->
   <depend>rviz</depend>
   <depend>mapviz</depend>
+  <depend>hector_trajectory_server</depend>
 
   <!-- Simulation -->
   <depend>gazebo_ros</depend>

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,4 @@
+# script to update and install software dependencies
+rosdep update
+rosdep install --from-paths ~/catkin_ws/src/ --ignore-src -y --rosdistro=noetic
+pip install -r ~/catkin_ws/src/mrover/requirements.txt


### PR DESCRIPTION
## Summary
Closes #114 (already closed but code got removed somehow)

added path plotting in RViz using hector trajectory server, added an update.sh script to update rosdep and pip deps without having to type out the entire command, removed ZED camera feed in basestation RViz config to reduce radio bandwidth consumption

### Did you add documentation to the wiki?
No, not really necessary (can add a note about the update script if we want)

## How was this code tested? 
ran RViz in sim and verified the path was working correctly, passed sim tests

### Did you test this in sim? 
Yes
### Did you test this on the rover?
No

### Did you add unit tests? 
No, nothing to unit test
