### PR TITLE
Publish map to base_link transform

### DIFF
--- a/config/drone.yaml
+++ b/config/drone.yaml
@@ -1,0 +1,3 @@
+mavros_tf_publisher:
+  world_frame: "map"
+  drone_frame: "base_link"

--- a/launch/drone.launch
+++ b/launch/drone.launch
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <launch>
+  <rosparam file="$(find mrover)/config/drone.yaml" command="load"/>
+
+  <node name="tf_pose_publisher" pkg="mrover" type="mavros_tf_publisher.py" output="screen" />
+
   <!-- MAVROS posix SITL environment launch script -->
   <!-- launches MAVROS, PX4 SITL, Gazebo environment, and spawns vehicle -->
   <!-- vehicle pose -->
@@ -13,7 +17,7 @@
   <arg name="est" default="ekf2"/>
   <arg name="vehicle" default="iris"/>
   <arg name="world" default="$(find mavlink_sitl_gazebo)/worlds/empty.world"/>
-  <arg name="sdf" default="$(find mavlink_sitl_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf"/>
+  <arg name="sdf" default="$(find mavlink_sitl_gazebo)/models/iris_depth_camera/iris_depth_camera.sdf"/>
 
   <!-- gazebo configs -->
   <arg name="gui" default="true"/>

--- a/src/drone/mavros_tf_publisher.py
+++ b/src/drone/mavros_tf_publisher.py
@@ -4,6 +4,7 @@ from util.SE3 import SE3
 from geometry_msgs.msg import PoseStamped
 import tf2_ros
 
+
 class MavrosTfPublisher:
     """
     This node subscribes to MAVROS's drone pose data,
@@ -17,7 +18,6 @@ class MavrosTfPublisher:
 
         self.world_frame = rospy.get_param("mavros_tf_publisher/world_frame")
         self.drone_frame = rospy.get_param("mavros_tf_publisher/drone_frame")
-
 
     def pose_callback(self, msg: PoseStamped):
         """

--- a/src/drone/mavros_tf_publisher.py
+++ b/src/drone/mavros_tf_publisher.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import rospy
+from util.SE3 import SE3
+from geometry_msgs.msg import PoseStamped
+import tf2_ros
+
+class MavrosTfPublisher:
+    """
+    This node subscribes to MAVROS's drone pose data,
+    and publishes it to the TF tree.
+    """
+
+    def __init__(self):
+        rospy.Subscriber("/mavros/local_position/pose", PoseStamped, self.pose_callback)
+
+        self.tf_broadcaster = tf2_ros.TransformBroadcaster()
+
+        self.world_frame = rospy.get_param("mavros_tf_publisher/world_frame")
+        self.drone_frame = rospy.get_param("mavros_tf_publisher/drone_frame")
+
+
+    def pose_callback(self, msg: PoseStamped):
+        """
+        Callback function that receives the drone's pose from MAVROS and publishes it to the TF tree.
+
+        :param msg: The pose message of the drone, in local coordinates
+        """
+        position = msg.pose.position
+        position = [position.x, position.y, position.z]
+
+        rotation = msg.pose.orientation
+        rotation = [rotation.x, rotation.y, rotation.z, rotation.w]
+        self.pose = SE3.from_pos_quat(position, rotation)
+        self.pose.publish_to_tf_tree(self.tf_broadcaster, parent_frame=self.world_frame, child_frame=self.drone_frame)
+
+
+def main():
+    # start the node and spin to wait for messages to be received
+    rospy.init_node("tf_pose_publisher")
+    MavrosTfPublisher()
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Closes #307 

Added a node that subscribes to the MAVROS local pose and publishes it to the TF tree. 

## How was this code tested? 
Output from rqt_tf_tree (/tf_pose_publisher broadcaster)
<img src="https://user-images.githubusercontent.com/22086974/212559657-b13c6772-8ec3-4abf-a0dc-30b841817fee.png" width=500px height=450px/>

Shortened output from `rosrun tf tf_echo /map /base_link`:

At time 10.152
- Translation: [0.002, -0.014, -0.071]
- Rotation: in Quaternion [-0.008, 0.011, -0.042, 0.999]
            in RPY (radian) [-0.016, 0.021, -0.084]
            in RPY (degree) [-0.917, 1.218, -4.813]

### Did you test this in sim? 
Yes