### PR TITLE
Adds tag expiration to get tag function

### DIFF
--- a/scripts/debug_course_publisher.py
+++ b/scripts/debug_course_publisher.py
@@ -32,5 +32,3 @@ if __name__ == "__main__":
     ]
 
     publish_waypoints([convert_waypoint_to_gps(waypoint) for waypoint in waypoints])
-
-    rospy.spin()

--- a/src/navigation/context.py
+++ b/src/navigation/context.py
@@ -65,7 +65,7 @@ class Environment:
         try:
             fid_pose, time = SE3.from_tf_time(self.ctx.tf_buffer, parent_frame="map", child_frame=f"fiducial{fid_id}")
             now = rospy.Time.now()
-            if now.time.to_sec() - time.time.to_sec() >= TAG_EXPIRATION_TIME_SECONDS:
+            if now.to_sec() - time.to_sec() >= TAG_EXPIRATION_TIME_SECONDS:
                 return None
         except (
             tf2_ros.LookupException,

--- a/src/navigation/context.py
+++ b/src/navigation/context.py
@@ -60,7 +60,7 @@ class Environment:
     def get_fid_pos(self, fid_id: int, frame: str = "map") -> Optional[np.ndarray]:
         """
         Retrieves the pose of the given fiducial ID from the TF tree
-        if it exists and is more recent than 60 seconds, otherwise returns None
+        if it exists and is more recent than TAG_EXPIRATION_TIME_SECONDS, otherwise returns None
         """
         try:
             fid_pose, time = SE3.from_tf_time(self.ctx.tf_buffer, parent_frame="map", child_frame=f"fiducial{fid_id}")


### PR DESCRIPTION
## Summary
Closes #225 

What features did you add, bugs did you fix, etc? 

AR tags expire after 60 seconds of not being seen

### Did you add documentation to the wiki?
No

## How was this code tested? 
Sim, drive to a tag, delete tag, wait time, run with same tag as target, rover doesn't realize tag is already there and misses it

### Did you test this in sim? 
Yes

### Did you test this on the rover?
No

### Did you add unit tests? 
No
