### PR TITLE
Update Install script to clone from ssh

### DIFF
--- a/install.py
+++ b/install.py
@@ -36,7 +36,7 @@ DRONE_ROS_APT_DEPS += [
     "libfuse2",
 ]
 
-MROVER_ROS_GIT_URL = "https://github.com/umrover/mrover-ros.git"
+MROVER_ROS_GIT_URL = "git@github.com:umrover/mrover-ros.git"
 PX4_GIT_URL = "https://github.com/px4/px4-autopilot"
 WIKI_URL = "https://github.com/umrover/mrover-ros/wiki"
 GROUND_CONTROL_URL = "https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage"


### PR DESCRIPTION
## Summary
Closes #193 

What features did you add, bugs did you fix, etc? 

Change install script to use ssh repo link.

### Did you add documentation to the wiki?
Yes -- added details about ssh keys here: https://github.com/umrover/mrover-ros/wiki/2.-Install-ROS

I guess we could update the script to generate ssh keys automatically but I figure some people will already have ssh keys set up if they've been using Linux. This is also so widely used that it couldn't hurt for people to be forced to learn a little bit about.

## How was this code tested? 
I guess I could nuke my repo and start fresh, tbd on that.