### PR TITLE
adjust auton gui format 

### DIFF
--- a/src/teleop/gui/src/components/AutonWaypointEditor.vue
+++ b/src/teleop/gui/src/components/AutonWaypointEditor.vue
@@ -91,8 +91,8 @@
             @toggle="toggleTeleopMode($event)"
           />
         </div>
-        <div class="stuck-check">
-          <Checkbox name="Stuck" @toggle="roverStuck = !roverStuck"></Checkbox>
+        <div class="stuck-check" style="padding-inline: 25px">
+          <Checkbox name="Stuck" style="transform: scale(1.5)" @toggle="roverStuck = !roverStuck" ></Checkbox>
         </div>
         <div class="stats">
           <VelocityCommand />

--- a/src/teleop/gui/src/components/AutonWaypointEditor.vue
+++ b/src/teleop/gui/src/components/AutonWaypointEditor.vue
@@ -91,8 +91,8 @@
             @toggle="toggleTeleopMode($event)"
           />
         </div>
-        <div class="stuck-check" style="padding-inline: 25px">
-          <Checkbox name="Stuck" style="transform: scale(1.5)" @toggle="roverStuck = !roverStuck" ></Checkbox>
+        <div class="stuck-check" >
+          <Checkbox class ="stuck-checkbox" name="Stuck" @toggle="roverStuck = !roverStuck"></Checkbox>
         </div>
         <div class="stats">
           <VelocityCommand />
@@ -545,6 +545,10 @@ export default {
 .stuck-check {
   align-content: center;
   grid-area: stuck-check;
+  padding-inline: 20px
+}
+.stuck-check .stuck-checkbox {
+  transform: scale(1.5);
 }
 
 .odom {

--- a/src/teleop/gui/src/components/IMUCalibration.vue
+++ b/src/teleop/gui/src/components/IMUCalibration.vue
@@ -61,10 +61,10 @@
         </tbody>
         <tbody>
           <tr>
-            <td class="tableElement">{{ magnetometer_val }}</td>
-            <td class="tableElement">{{ accelerometer_val }}</td>
-            <td class="tableElement">{{ gyroscope_val }}</td>
-            <td class="tableElement">{{ system_val }}</td>
+            <td class="tableElement">{{ magnetometer_val.toFixed(3) }}</td>
+            <td class="tableElement">{{ accelerometer_val.toFixed(3) }}</td>
+            <td class="tableElement">{{ gyroscope_val.toFixed(3) }}</td>
+            <td class="tableElement">{{ system_val.toFixed(3) }}</td>
           </tr>
         </tbody>
       </table>

--- a/src/teleop/gui/src/components/JoystickValues.vue
+++ b/src/teleop/gui/src/components/JoystickValues.vue
@@ -2,15 +2,15 @@
   <div class="datagrid">
     <div>
       <p style="margin-top: 0px">
-        left_right: {{ joystick_values.left_right }}
+        left_right: {{ joystick_values.left_right.toFixed(3) }}
       </p>
-      <p>forward_back: {{ joystick_values.forward_back }}</p>
-      <p>twist: {{ joystick_values.twist }}</p>
+      <p>forward_back: {{ joystick_values.forward_back.toFixed(3) }}</p>
+      <p>twist: {{ joystick_values.twist.toFixed(3) }}</p>
     </div>
     <div>
-      <p style="margin-top: 0px">dampen: {{ joystick_values.dampen }}</p>
-      <p>pan: {{ joystick_values.pan }}</p>
-      <p>tilt: {{ joystick_values.tilt }}</p>
+      <p style="margin-top: 0px">dampen: {{ joystick_values.dampen.toFixed(3) }}</p>
+      <p>pan: {{ joystick_values.pan.toFixed(3) }}</p>
+      <p>tilt: {{ joystick_values.tilt.toFixed(3) }}</p>
     </div>
   </div>
 </template>

--- a/src/teleop/gui/src/components/VelocityCommand.vue
+++ b/src/teleop/gui/src/components/VelocityCommand.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <!--Velocity Commands<br />-->
     Velocity Command<br />
     Lin: {{ linear_x.toFixed(3) }} m/s<br />
     Ang: {{ angular_z.toFixed(3) }} rad/s

--- a/src/teleop/gui/src/components/VelocityCommand.vue
+++ b/src/teleop/gui/src/components/VelocityCommand.vue
@@ -1,8 +1,9 @@
 <template>
   <div>
-    Velocity Commands<br />
-    Linear x: {{ linear_x }} m/s<br />
-    Angular z: {{ angular_z }} rad/s
+    <!--Velocity Commands<br />-->
+    Velocity Command<br />
+    Lin: {{ linear_x.toFixed(3) }} m/s<br />
+    Ang: {{ angular_z.toFixed(3) }} rad/s
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
Closes #

What features did you add, bugs did you fix, etc? 
Made the Stuck button on the auton gui bigger and changed the numbers displayed on the auton gui limited to 3 decimals, including joystick values, imu calibration values and velocity commands. Also changed "Linear x" to "Lin" and "Angular z" to "Ang" so it can fit in one line 

### Did you add documentation to the wiki?
No 

## How was this code tested? 
we tested values more than 3 decimals 
<img width="346" alt="Screenshot 2023-03-23 at 9 44 38 PM" src="https://user-images.githubusercontent.com/98134028/227405924-e331517e-a911-4655-91ee-a3977ebb29f1.png">

### Did you test this in sim? 
No

### Did you test this on the rover?
No

### Did you add unit tests? 
testing was completed 
