### PR TITLE
Make CI pull pip requirements

### DIFF
--- a/.github/workflows/catkin.yml
+++ b/.github/workflows/catkin.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Initialize catkin workspace
         run: . /opt/ros/noetic/setup.sh && catkin init
       - name: Build
-        run: . /opt/ros/noetic/setup.sh && catkin build --interleave-output --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_CLANG_TIDY=clang-tidy-12
+        run: . /opt/ros/noetic/setup.sh && catkin build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_CLANG_TIDY=clang-tidy-12
+      - name: Python requirements
+        run: pip3 install -r $GITHUB_WORKSPACE/src/requirements.txt
       - name: Test
         run: . /opt/ros/noetic/setup.sh && . $GITHUB_WORKSPACE/devel/setup.sh && catkin test -j1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Style check C++/Python
-        run: ./style.sh
+        run: $GITHUB_WORKSPACE/style.sh


### PR DESCRIPTION
## Summary

Makes the CI pip3 install the requirements before running. The idea is that this will speed up people getting their Python code merged into master. When the docker image updates the pip3 update will barely do anything and be fast.

### Did you add documentation to the wiki?
No

## How was this code tested? 
With https://github.com/nektos/act

```
gh extension install https://github.com/nektos/gh-act
gh act
```

`gh` is the GitHub CLI app: https://cli.github.com/ highly recommended in general.
