### PR TITLE
Publish MotorsStatus message in sim

### DIFF
--- a/src/gazebo/differential_drive_6w.cpp
+++ b/src/gazebo/differential_drive_6w.cpp
@@ -165,7 +165,7 @@ namespace gazebo {
         // update path at 4 Hz
         mPathUpdatePeriod = common::Time(0, static_cast<int32_t>(common::Time::SecToNano(0.25)));
 
-        mMotorStatus.joint_states.name.resize(6);
+        mMotorStatus.joint_states.name.resize(mJoints.size());
         mMotorStatus.joint_states.position.resize(mJoints.size());
         mMotorStatus.joint_states.velocity.resize(mJoints.size());
         mMotorStatus.joint_states.effort.resize(mJoints.size());

--- a/src/gazebo/differential_drive_6w.hpp
+++ b/src/gazebo/differential_drive_6w.hpp
@@ -92,7 +92,7 @@ namespace gazebo {
         double mTorque{};
         std::array<double, 2> mWheelSpeeds{};
 
-        // SimulationmJointStateP time of the last update
+        // SimulationmJointState time of the last update
         common::Time mPreviousUpdateTime;
 
         // Sim time of last time path was updated and published

--- a/src/gazebo/differential_drive_6w.hpp
+++ b/src/gazebo/differential_drive_6w.hpp
@@ -92,7 +92,7 @@ namespace gazebo {
         double mTorque{};
         std::array<double, 2> mWheelSpeeds{};
 
-        // SimulationmJointState time of the last update
+        // Simulation time of the last update
         common::Time mPreviousUpdateTime;
 
         // Sim time of last time path was updated and published

--- a/src/gazebo/differential_drive_6w.hpp
+++ b/src/gazebo/differential_drive_6w.hpp
@@ -54,6 +54,9 @@
 
 #include <gazebo/common/UpdateInfo.hh>
 
+#include <mrover/MotorsStatus.h>
+#include <sensor_msgs/JointState.h>
+
 namespace gazebo {
 
     class DiffDrivePlugin6W : public ModelPlugin {
@@ -72,6 +75,7 @@ namespace gazebo {
 
     private:
         void publishOdometry();
+        void publishJointData();
         void publishPath();
 
         void getPositionCommand();
@@ -79,13 +83,16 @@ namespace gazebo {
         physics::LinkPtr mBodyLink;
         physics::WorldPtr mWorld;
         std::array<physics::JointPtr, 6> mJoints;
+        mrover::MotorsStatus mMotorStatus{};
+        //publisher for joint state message
+        ros::Publisher mJointStatePublisher;
 
         double mWheelSeparation{};
         double mWheelDiameter{};
         double mTorque{};
         std::array<double, 2> mWheelSpeeds{};
 
-        // Simulation time of the last update
+        // SimulationmJointStateP time of the last update
         common::Time mPreviousUpdateTime;
 
         // Sim time of last time path was updated and published


### PR DESCRIPTION
## Summary
Closes no issue opened

What features did you add, bugs did you fix, etc? 

Currently ESW publishes MotorsStatus messages for the drive system but its not published in sim. I updated the diff drive plugin so that it does that.

### Did you add documentation to the wiki?
No

## How was this code tested? 
Sim and echoed message output

### Did you test this in sim? 
Yes

### Did you test this on the rover?
No

### Did you add unit tests? 
No
