### PR TITLE
Add "Competiton mode" toggle for GUI to choose which ROS IP to look for.

### DIFF
--- a/src/teleop/gui/src/app.js
+++ b/src/teleop/gui/src/app.js
@@ -12,6 +12,9 @@ Vue.prototype.$ros = new ROSLIB.Ros({
   url: "ws://10.0.0.7:9090",
 });
 
+// For whether we are on basestation or not
+Vue.prototype.$competitionMode = false;
+
 /* eslint-disable no-new */
 new Vue({
   el: "#app",

--- a/src/teleop/gui/src/components/Menu.vue
+++ b/src/teleop/gui/src/components/Menu.vue
@@ -10,6 +10,14 @@
       />
       <h1>Menu</h1>
       <div class="spacer"></div>
+      <div class="mode-toggle">
+        <ToggleButton
+          :label-enable-text="'Competition Mode On'"
+          :label-disable-text="'Competition Mode Off'"
+          :current-state="competitionMode"
+          @change="toggleCompetitionMode()"
+        ></ToggleButton>
+      </div>
     </div>
 
     <div class="pages">
@@ -29,13 +37,47 @@
 
 <script>
 import MenuButton from "./MenuButton.vue";
+import ToggleButton from "./ToggleButton.vue";
+import Vue from "vue";
+import ROSLIB from "roslib";
 
 export default {
-  name: "Menu",
-
+  name: "MainMenu",
   components: {
     MenuButton,
+    ToggleButton
   },
+
+  data() {
+    return {
+      competitionMode: true
+    };
+  },
+
+  watch: {
+    competitionMode: function (val) {
+      if (val) {
+        Vue.prototype.$ros = new ROSLIB.Ros({
+          url: "ws://10.0.0.7:9090"
+        });
+      } else {
+        Vue.prototype.$ros = new ROSLIB.Ros({
+          url: "ws://localhost:9090"
+        });
+      }
+    }
+  },
+
+  created: function () {
+    this.competitionMode = Vue.prototype.$competitionMode;
+  },
+
+  methods: {
+    toggleCompetitionMode() {
+      this.competitionMode = !this.competitionMode;
+      Vue.prototype.$competitionMode = this.competitionMode;
+    }
+  }
 };
 </script>
 
@@ -84,5 +126,9 @@ img {
   grid-template-areas: "header" "pages";
   font-family: sans-serif;
   height: auto;
+}
+
+.mode-toggle {
+  margin-left: auto;
 }
 </style>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/71604997/233750845-2019af4d-2087-41d5-9b32-06b7480b5565.png)
Fixes issue that @tabiosg brought up in dev-ops about the change of the GUI ROSLIB IP to 10.0.0.7

## Summary
Closes #(Your issue number here)

What features did you add, bugs did you fix, etc? 

### Did you add documentation to the wiki?
Yes/No (If not explain why not)

## How was this code tested? 
Summarize how you tested this code. Your objective here is to prove to the reviewers that this code actually works without them having to run it themselves. It is often helpful to include screenshots, tables, graphs, and/or a short write-up of testing procedures. Results can be either from sim, the robot, or both depending on what you think is sufficient for the feature you added. 

### Did you test this in sim? 
Yes/No

### Did you test this on the rover?
Yes/No

### Did you add unit tests? 
Yes/No (If not explain why not) 
