### PR TITLE
Just one launch argument for odom frame or no odom frame

### DIFF
--- a/config/ekf.yaml
+++ b/config/ekf.yaml
@@ -34,18 +34,6 @@ global_ekf:
   print_diagnostics: true
   publish_tf: true
 
-  # odom frame off
-  # map_frame: none
-  # odom_frame: map
-  # base_link_frame: base_link
-  # world_frame: map
-
-  # odom frame on
-  map_frame: map
-  odom_frame: odom
-  base_link_frame: base_link
-  world_frame: map
-
   # IMU accel and gyro
   # imu0: imu/imu_only
 

--- a/config/localization.yaml
+++ b/config/localization.yaml
@@ -1,7 +1,6 @@
 world_frame: "map"
 odom_frame: "odom"
 rover_frame: "base_link"
-use_odom_frame: true
 
 gps_linearization:
   reference_point_latitude: 42.293195

--- a/launch/auton.launch
+++ b/launch/auton.launch
@@ -4,6 +4,9 @@
     <arg name="sim" default="false"/>
     <arg name="use_ekf" default="true"/>
     <arg name="ekf_start_delay" default="0"/>
+    <arg name="use_odom_frame" default="true"/>
+
+    
 
     <!--
       ==========
@@ -55,4 +58,17 @@
         <param name="trajectory_update_rate" type="double" value="4"/>
         <param name="trajectory_publish_rate" type="double" value="4"/>
     </node>
+
+    <!--
+      Set rosparams required for odom frame if its true, else set them correclty to not use odom frame
+    -->
+    <param if="$(arg use_odom_frame)" name="use_odom_frame" value="true"/>
+    <param unless="$(arg use_odom_frame)" name="use_odom_frame" value="false"/>
+    <param if="$(arg use_odom_frame)" name="odom_frame" value="odom"/>
+    <param unless="$(arg use_odom_frame)" name="odom_frame" value="map"/>
+    <param if="$(arg use_odom_frame)" name="map_frame" value="map"/>
+    <param unless="$(arg use_odom_frame)" name="map_frame" value="none"/>
+    <param name="base_link_frame" value="base_link"/>
+    <param name="world_frame" value="map"/>
+ 
 </launch>

--- a/launch/auton_sim.launch
+++ b/launch/auton_sim.launch
@@ -4,7 +4,7 @@
 <launch>
     <arg name="rvizconfig" default="$(find mrover)/config/rviz/auton_sim.rviz"/>
     <arg name="world_name" default="world"/>
-    <arg name="use_odom" default="true"/>
+    <arg name="use_odom" default="false"/>
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true"/>
 
@@ -48,5 +48,6 @@
         <arg name="sim" value="true"/>
         <arg name="use_ekf" value="true"/>
         <arg name="ekf_start_delay" value="10.0"/>
+        <arg name="use_odom_frame" value="$(arg use_odom)"/>
     </include>
 </launch>

--- a/launch/jetson_auton.launch
+++ b/launch/jetson_auton.launch
@@ -1,7 +1,10 @@
 <launch>
+    <arg name="use_odom_frame" default="true"/>
     <include file="$(find mrover)/launch/jetson.launch"/>
     <include file="$(find mrover)/launch/zed.launch">
-        <arg name="use_builtin_visual_odom" value="true"/>
+        <arg name="use_builtin_visual_odom" value="$(arg use_odom_frame)"/>
     </include>
-    <include file="$(find mrover)/launch/auton.launch"/>
+    <include file="$(find mrover)/launch/auton.launch">
+        <arg name="use_odom_frame" value="$(arg use_odom_frame)"/>
+    </include>
 </launch>


### PR DESCRIPTION
## Summary
Makes it so we only have one thing to change to turn on and off the odom frame. Within auton_sim.launch there is a parameter called use_odom and within jetson_auton.launch there is a parameter called use_odom_frame and based on those parameters auton.launch sets all the necessary rosparams (and that param is passed to zed.launch as well). I also removed all the parameters from the yamls so that we don't change them there by mistake thinking it will have an effect.

What features did you add, bugs did you fix, etc? 

### Did you add documentation to the wiki?
No

## How was this code tested? 
Ran in sim and then rosparam get values in both cases to make sure they are all right

### Did you test this in sim? 
Yes

### Did you test this on the rover?
no

### Did you add unit tests? 
no
