### PR TITLE
Publish available cameras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MROVER_PACKAGES
 
 # Message files
 set(MROVER_MESSAGE_FILES
+        AvailableCameras.msg
         Calibrated.msg
         CalibrationStatus.msg
         CameraCmd.msg

--- a/msg/AvailableCameras.msg
+++ b/msg/AvailableCameras.msg
@@ -1,0 +1,2 @@
+int32 num_available
+string[] camera_types  # names of camera type (e.g., regular, microscope, etc.)

--- a/src/esw/cameras.py
+++ b/src/esw/cameras.py
@@ -308,10 +308,6 @@ class StreamManager:
             rospy.logerr(f"Camera device ID {device_id} is not supported, max is {self.MAX_DEVICE_ID}")
             return self._get_change_response(False)
 
-        # The client's device is passed into the actual device array, so then we get device_id
-        # Then we just update the request to use the actually mapped device_id
-        req.camera_cmd.device = device_id
-
         with self._lock:
             # Reset the stream object if it exists. If it was running, this finalizes the stream
             # object, which in turn kills the process and resets the command.

--- a/src/esw/cameras.py
+++ b/src/esw/cameras.py
@@ -212,9 +212,9 @@ class StreamManager:
     Publishes the available cameras.
     """
 
-    _available_cams_lock: Lock
+    _available_cameras_lock: Lock
     """
-    A lock that protects member variables _device_arr and _camera_types.
+    A lock that protects member variable _available_cameras.
     """
 
     _available_cameras: List[AvailableCamera]
@@ -224,7 +224,7 @@ class StreamManager:
 
     def __init__(self):
         self._lock = Lock()
-        self._available_cams_lock = Lock()
+        self._available_cameras_lock = Lock()
 
         self._stream_by_device = [None for _ in range(self.MAX_DEVICE_ID)]
         self._primary_cmds = [CameraCmd(-1, -1) for _ in range(StreamManager.MAX_STREAMS)]
@@ -244,7 +244,7 @@ class StreamManager:
             # If the camera_type is unsupported (""), then ignore it.
             if camera_type != "":
                 available_cameras.append(AvailableCamera(device_id, camera_type))
-        with self._available_cams_lock:
+        with self._available_cameras_lock:
             self._available_cameras = available_cameras
 
     def publish_available_cameras(self, event=None) -> None:
@@ -252,7 +252,7 @@ class StreamManager:
         Publish list of available cameras
         """
         self._update_available_cameras()
-        with self._available_cams_lock:
+        with self._available_cameras_lock:
             device_arr = [available_camera.id for available_camera in self._available_cameras]
             camera_types = [available_camera.type for available_camera in self._available_cameras]
         available_cameras = AvailableCameras(num_available=len(device_arr), camera_types=camera_types)
@@ -292,9 +292,9 @@ class StreamManager:
         :return: A corresponding response.
         """
 
-        # Get most up to date available cameras
+        # Get most up-to-date available cameras
         self._update_available_cameras()
-        with self._available_cams_lock:
+        with self._available_cameras_lock:
             device_arr = [available_camera.id for available_camera in self._available_cameras]
             camera_types = [available_camera.type for available_camera in self._available_cameras]
 

--- a/src/esw/cameras.py
+++ b/src/esw/cameras.py
@@ -90,9 +90,9 @@ def get_camera_type(video_device: str) -> str:
     vendor = ""
 
     for line in output.decode().splitlines():
-        if "VENDOR_ID" in line:
+        if line.startswith("E: ID_VENDOR_ID="):
             vendor_id = line.split("=")[1].strip()
-        if "VENDOR" in line:
+        if line.startswith("E: ID_VENDOR="):
             vendor = line.split("=")[1].strip()
 
     for name in CAMERA_TYPE_INFO_BY_NAME:

--- a/src/esw/cameras.py
+++ b/src/esw/cameras.py
@@ -308,6 +308,12 @@ class StreamManager:
             rospy.logerr(f"Camera device ID {device_id} is not supported, max is {self.MAX_DEVICE_ID}")
             return self._get_change_response(False)
 
+        # The client's device is passed into the actual device array, so then we get device_id
+        # Then we just update the request to use the actually mapped device_id
+
+        original_req_dev_id = req.camera_cmd.device
+        req.camera_cmd.device = device_id
+
         with self._lock:
             # Reset the stream object if it exists. If it was running, this finalizes the stream
             # object, which in turn kills the process and resets the command.
@@ -340,7 +346,7 @@ class StreamManager:
                 cmd_obj = self._get_open_cmd_slot(req.primary)
 
                 self._stream_by_device[device_id] = Stream(
-                    req, cmd_obj, available_port, camera_types[req.camera_cmd.device]
+                    req, cmd_obj, available_port, camera_types[original_req_dev_id]
                 )
 
             return self._get_change_response(True)

--- a/src/esw/cameras.py
+++ b/src/esw/cameras.py
@@ -201,7 +201,7 @@ class StreamManager:
     The commands requested by the secondary IP endpoint.
     """
 
-    _available_cams_pub: rospy.publisher
+    _available_cams_pub: rospy.Publisher
     """
     Publishes the available cameras
     """

--- a/src/teleop/gui/src/components/Cameras.vue
+++ b/src/teleop/gui/src/components/Cameras.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="wrap">
-    <h3>Cameras</h3>
+    <h3>Cameras ({{ num_available }} available)</h3>
     <div class="input">
       Camera name:
       <input v-model="cameraName" class="rounded" type="message" /> Camera
@@ -68,7 +68,10 @@ export default {
       cameraName: "",
       capacity: 2,
       qualities: new Array(9).fill(-1),
-      streamOrder: [-1, -1, -1, -1]
+      streamOrder: [-1, -1, -1, -1],
+
+      available_sub: null,
+      num_available: -1
     };
   },
 
@@ -104,6 +107,16 @@ export default {
       primary: this.primary
     });
     resetService.callService(request, (result) => {});
+
+    this.available_sub = new ROSLIB.Topic({
+      ros: this.$ros,
+      name: "available_cameras",
+      messageType: "mrover/AvailableCameras"
+    });
+
+    this.available_sub.subscribe((msg) => {
+      this.num_available = msg.num_available;
+    });
   },
 
   methods: {


### PR DESCRIPTION
It would be nice to have the GUI listen to available_cameras for the AvailableCameras.msg to either filter out specific buttons or automatically name Cameras.

AvailableCameras.msg has the number of available cameras that the operator can select from (as an integer num_available).
It also has the names of each camera type (in an array of strings camera_types)

Teleop Part:
1. Make it obvious to the operator the available cameras they can select from (by default, if no one publishes to the topic, the GUI should allow operators to select any camera. However, if the topic says that num_available is 2, then the GUI should only allow the user to select either Camera 0 or Camera 1). 

2. Help out with automatic renaming. If the name is microscope, then rename to microscope. If the name is rock_4k, then rename to rock_4k. If it is anything else, do NOT rename it.