### PR TITLE
Add VSCode sane defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,19 @@
-# Python Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
 *.py[cod]
 *$py.class
 .mypy_cache/
 *.egg-info/
+/venv/
 
 # Common IDE's, ideally this should be in global gitignore per user
 .vscode/
 .idea/
-/cmake-build*/
+.cache/
+cmake-build*/
+/build/
 
-#GUI Files
+# GUI Files
 node_modules/
 /src/teleop/gui/dist/
 /src/teleop/gui/src/static/map
@@ -21,19 +24,8 @@ yarn-error.log*
 # Bag Files
 /bags/
 
-# Catkin
-/build/
-/devel/
-/logs/
-
 # Moteus
 moteus-cal*
 
 # CSV
 *.csv
-
-# Virtual Environment
-/venv/
-
-# clangd Output
-.cache/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "redhat.vscode-xml",
+        "redhat.vscode-yaml",
+        "llvm-vs-code-extensions.vscode-clangd",
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack",
+    ],
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,8 @@
         "ms-vscode.cpptools",
         "ms-vscode.cmake-tools",
         "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "ms-python.mypy-type-checker",
         "dbaeumer.vscode-eslint",
         "redhat.vscode-xml",
         "redhat.vscode-yaml",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
         "ms-vscode.cmake-tools",
         "ms-python.vscode-pylance",
         "ms-python.black-formatter",
-        "ms-python.mypy-type-checker",
         "dbaeumer.vscode-eslint",
         "redhat.vscode-xml",
         "redhat.vscode-yaml",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,11 @@
 {
     "recommendations": [
-        "ms-python.python",
         "ms-vscode.cpptools",
         "ms-vscode.cmake-tools",
+        "ms-python.vscode-pylance",
+        "dbaeumer.vscode-eslint",
         "redhat.vscode-xml",
         "redhat.vscode-yaml",
         "llvm-vs-code-extensions.vscode-clangd",
-    ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack",
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+    //// Cmake
+    "cmake.generator": "Unix Makefiles",
+    "cmake.buildDirectory": "${workspaceFolder}/../../build/mrover",
+    // We want catkin to configure
+    "cmake.configureOnOpen": false,
+    "cmake.configureOnEdit": false,
+    "cmake.automaticReconfigure": false,
+    //// Microsoft C++
+    // Disable since clangd is used instead
+    "C_Cpp.intelliSenseEngine": "disabled",
+    //// Python
+    "python.analysis.inlayHints.variableTypes": true,
+    "python.analysis.inlayHints.callArgumentNames": "all",
+    "python.analysis.inlayHints.functionReturnTypes": true,
+    "python.autoComplete.extraPaths": [
+        "/opt/ros/noetic/lib/python3/dist-packages",
+        "${workspaceFolder}/../../devel/lib/python3/dist-packages",
+    ],
+    "python.analysis.extraPaths": [
+        "/opt/ros/noetic/lib/python3/dist-packages",
+        "${workspaceFolder}/../../devel/lib/python3/dist-packages",
+    ],
+    //// Miscellaneous
+    "redhat.telemetry.enabled": false,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     // but Pylance currently has a bug where it cannot handle the symlinks in it.
     // Below we are just putting directly where those symlinks go
     "python.analysis.extraPaths": [
+        "/opt/ros/noetic/lib/python3/dist-packages",
         "../../devel/.private/mrover/lib/python3/dist-packages",
     ],
     "[python]": {
@@ -32,4 +33,5 @@
     "python.analysis.typeCheckingMode": "off",
     //// Miscellaneous
     "redhat.telemetry.enabled": false,
+    "editor.formatOnSave": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     // Catkin only works with Make... ideally we could use Ninja
     "cmake.generator": "Unix Makefiles",
     // Set to the catkin build directory
-    "cmake.buildDirectory": "${workspaceFolder}/../../build/mrover",
+    "cmake.buildDirectory": "../../build/mrover",
     // We want catkin to configure
     // VSCode will try to use its own toolchain and ignore the catkin profile
     "cmake.configureOnOpen": false,
@@ -19,21 +19,17 @@
     "python.analysis.inlayHints.variableTypes": true,
     "python.analysis.inlayHints.callArgumentNames": "all",
     "python.analysis.inlayHints.functionReturnTypes": true,
-    "python.autoComplete.extraPaths": [
-        "/opt/ros/noetic/lib/python3/dist-packages",
-        "${workspaceFolder}/../../devel/lib/python3/dist-packages",
-    ],
+    // ~/catkin_ws/devel/lib/python3/dist-packages is already in PYTHONPATH,
+    // but Pylance currently has a bug where it cannot handle the symlinks in it.
+    // Below we are just putting directly where those symlinks go
     "python.analysis.extraPaths": [
-        "/opt/ros/noetic/lib/python3/dist-packages",
-        "${workspaceFolder}/../../devel/lib/python3/dist-packages",
+        "../../devel/.private/mrover/lib/python3/dist-packages",
     ],
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
     },
-    "mypy-type-checker.args": [
-        "--config-file=${workspaceFolder}/mypy.ini",
-    ],
+    // We use mypy for this, see style.sh
+    "python.analysis.typeCheckingMode": "off",
     //// Miscellaneous
     "redhat.telemetry.enabled": false,
-    "python.analysis.typeCheckingMode": "basic",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,10 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
     },
+    "mypy-type-checker.args": [
+        "--config-file=${workspaceFolder}/mypy.ini",
+    ],
     //// Miscellaneous
     "redhat.telemetry.enabled": false,
+    "python.analysis.typeCheckingMode": "basic",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
     "cmake.configureOnOpen": false,
     "cmake.configureOnEdit": false,
     "cmake.automaticReconfigure": false,
+    "cmake.debugConfig": {
+        "miDebuggerPath": "/usr/bin/gdb",
+    },
     //// Microsoft C++
     // Disable since clangd is used instead
     "C_Cpp.intelliSenseEngine": "disabled",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,11 @@
 {
     //// Cmake
+    // Catkin only works with Make... ideally we could use Ninja
     "cmake.generator": "Unix Makefiles",
+    // Set to the catkin build directory
     "cmake.buildDirectory": "${workspaceFolder}/../../build/mrover",
     // We want catkin to configure
+    // VSCode will try to use its own toolchain and ignore the catkin profile
     "cmake.configureOnOpen": false,
     "cmake.configureOnEdit": false,
     "cmake.automaticReconfigure": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,9 @@
         "/opt/ros/noetic/lib/python3/dist-packages",
         "${workspaceFolder}/../../devel/lib/python3/dist-packages",
     ],
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+    },
     //// Miscellaneous
     "redhat.telemetry.enabled": false,
 }


### PR DESCRIPTION
This should help with people who just set up their Ubuntu and are on the starter project.

`extensions.json` defines recommended extensions, it should pop up when first accessing the folder.

`settings.json` configures sane defaults for these extensions.

Note that ms c++ and clangd are installed at the same time. In the settings the intellisense from ms is turned off so that clangd is used instead. ms is needed for debugging.

the cmake plugin is also configured to use the build folder in the catkin workspace. Ideally `catkin build` is done before ever opening vscode to get this working properly.

inlay hints are added to python and the missing dist-packages are added.
