### PR TITLE
Improve CMake. Automatically find message and service files. Add many utility macros.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,94 +3,69 @@ project(mrover VERSION 2024.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Generate compile_commands.json for clangd
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_link_options(-fuse-ld=lld-16)
+    add_link_options(-fuse-ld=lld-16) # LLVM lld is faster than GNU ld
 endif ()
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(MROVER_CPP_COMPILE_OPTIONS -Wall -Wextra -Werror -pedantic)
 endif ()
 
-# Generate compile_commands.json for clangd
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 # ROS packages list
-set(MROVER_PACKAGES
+set(MROVER_ROS_DEPENDENCIES
         rospy
         roscpp
+        rostest
+        nodelet
         std_msgs
+        sensor_msgs
         message_generation
         dynamic_reconfigure
-        rostest
-        sensor_msgs
+        tf2
+        tf2_ros
+        tf2_geometry_msgs
+        gazebo_ros
 )
 
-# Message files
-set(MROVER_MESSAGE_FILES
-        CalibrationStatus.msg
-        CameraCmd.msg
-        CAN.msg
-        Chassis.msg
-        ControllerGroupState.msg
-        ControllerState.msg
-        Course.msg
-        EnableAuton.msg
-        GPSPointList.msg
-        GPSWaypoint.msg
-        HeaterData.msg
-        ImuAndMag.msg
-        LED.msg
-        MoteusState.msg
-        MotorsStatus.msg
-        NavMetadata.msg
-        NavState.msg
-        NetworkBandwidth.msg
-        PDB.msg
-        Position.msg
-        ScienceThermistors.msg
-        Spectral.msg
-        SpectralGroup.msg
-        Throttle.msg
-        Velocity.msg
-        Waypoint.msg
-        WaypointType.msg
-        GPSPointList.msg
-)
+# Search a path for all files matching a glob pattern and extract the filenames
+macro(extract_filenames directory_path out_file_names)
+    file(GLOB_RECURSE full_paths ${directory_path})
+    set(${out_file_names} "")
+    foreach (FULL_PATH ${full_paths})
+        get_filename_component(FILE_NAME ${FULL_PATH} NAME)
+        list(APPEND ${out_file_names} ${FILE_NAME})
+    endforeach ()
+endmacro()
 
-# Service files
-set(MROVER_SERVICE_FILES
-        AdjustMotor.srv
-        ChangeArmMode.srv
-        ChangeCameras.srv
-        FetchMessageFromPackage.srv
-        FetchPackages.srv
-        PublishCourse.srv
-        PublishEnableAuton.srv
-)
+extract_filenames(msg/*.msg MROVER_MESSAGE_FILES)
 
-# Generate messages list
-set(MROVER_ROS_MESSAGES
-        sensor_msgs
+extract_filenames(srv/*.srv MROVER_SERVICE_FILES)
+
+set(MROVER_MESSAGE_DEPENDENCIES
         std_msgs
         sensor_msgs
 )
 
-# Dynamic reconfigure parameter file list
 set(MROVER_PARAMETERS
         config/DetectorParams.cfg
 )
 
-# catkin packages list
-set(MROVER_CATKIN_PACKAGES
-        roscpp rospy std_msgs message_runtime
+set(MROVER_CMAKE_INCLUDES
+        starter_project/autonomy/AutonomyStarterProject.cmake
 )
 
-macro(rosify_cpp_target_macro target)
+### ====== ###
+### Macros ###
+### ====== ###
+
+macro(target_rosify target)
     target_link_libraries(${target} PRIVATE ${catkin_LIBRARIES})
     target_include_directories(${target} SYSTEM PRIVATE ${catkin_INCLUDE_DIRS} src/util)
     add_dependencies(${target} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
     target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${MROVER_CPP_COMPILE_OPTIONS}>)
 
+    # Installing is necessary for roslaunch to find the node
     install(TARGETS ${target}
             ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
             LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -98,31 +73,54 @@ macro(rosify_cpp_target_macro target)
     )
 endmacro()
 
-macro(add_cpp_library_macro name sources includes)
+macro(mrover_add_library name sources includes)
     file(GLOB_RECURSE CPP_LIB_SOURCES ${sources})
     add_library(${name} ${CPP_LIB_SOURCES})
     target_include_directories(${name} PUBLIC ${includes})
-    rosify_cpp_target_macro(${name})
+    target_rosify(${name})
 endmacro()
 
-macro(add_cpp_interface_library_macro name includes)
+macro(mrover_add_header_only_library name includes)
     add_library(${name} INTERFACE)
     target_include_directories(${name} INTERFACE ${includes})
 endmacro()
 
-macro(add_cpp_node_macro name sources)
-    file(GLOB_RECURSE CPP_NODE_SOURCES ${sources})
-    add_executable(${name} ${CPP_NODE_SOURCES})
-    rosify_cpp_target_macro(${name})
+macro(mrover_add_node name sources)
+    file(GLOB_RECURSE NODE_SOURCES ${sources})
+    add_executable(${name} ${NODE_SOURCES})
+    target_rosify(${name})
 endmacro()
 
-macro(add_cpp_nodelet_macro name sources includes)
+macro(mrover_add_nodelet name sources includes)
     # A nodelet runs inside another process so it is a library
-    add_cpp_library_macro(${name} ${sources} ${includes})
+    mrover_add_library(${name}_node ${sources} ${includes})
+    # Also add a node for quick debugging
+    mrover_add_node(${name}_nodelet ${sources})
+    target_compile_definitions(${name}_nodelet PRIVATE MROVER_IS_NODELET)
+    # Optional PCH
+    if (ARGV3)
+        target_precompile_headers(${name}_node PRIVATE ${ARGV3})
+        target_precompile_headers(${name}_nodelet PRIVATE ${ARGV3})
+    endif ()
 endmacro()
 
-macro(add_gazebo_plugin_macro name sources includes)
-    add_cpp_library_macro(${name} ${sources} ${includes})
+macro(mrover_nodelet_link_libraries name)
+    target_link_libraries(${name}_node PRIVATE ${ARGN})
+    target_link_libraries(${name}_nodelet PRIVATE ${ARGN})
+endmacro()
+
+macro(mrover_nodelet_include_directories name)
+    target_include_directories(${name}_node SYSTEM PRIVATE ${ARGN})
+    target_include_directories(${name}_nodelet SYSTEM PRIVATE ${ARGN})
+endmacro()
+
+macro(mrover_nodelet_defines name)
+    target_compile_definitions(${name}_node PRIVATE ${ARGN})
+    target_compile_definitions(${name}_nodelet PRIVATE ${ARGN})
+endmacro()
+
+macro(mrover_add_gazebo_plugin name sources includes)
+    mrover_add_library(${name} ${sources} ${includes})
 
     # TODO: find a proper variable name that points to /opt/ros/noetic/lib
     target_link_directories(${name} PRIVATE ${GAZEBO_LIBRARY_DIRS} /opt/ros/noetic/lib)
@@ -131,161 +129,41 @@ macro(add_gazebo_plugin_macro name sources includes)
     set_target_properties(${name} PROPERTIES CXX_STANDARD 17)
 endmacro()
 
-# launch install macro
-macro(install_launch_macro)
-    install(DIRECTORY launch/
-            DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-    )
-endmacro()
+### ============ ###
+### Dependencies ###
+### ============ ###
 
-macro(add_tests_macro)
-    # Add C++ unit tests
-    catkin_add_gtest(example-cpp-test test/example/cpp_test.cpp)
-
-    # Python unit tests
-    catkin_add_nosetests(test/navigation/drive_test.py)
-    catkin_add_nosetests(test/teleop/teleop_test.py)
-    catkin_add_nosetests(test/util/SE3_test.py)
-    catkin_add_nosetests(test/util/SO3_test.py)
-
-    # Integration tests (python and c++)
-    find_package(rostest REQUIRED)
-    add_rostest(test/example/basic_integration_test.test)
-    add_rostest(test/integration/integration.test)
-    add_rostest(test/util/SE3_tf_test.test)
-endmacro()
-
-# Subdirectories before message declarations
-set(MROVER_CMAKE_INCLUDES "")
-
-
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Specify build details by appending to lists
-# and implementing the some extra macros
-# Add new devices as elseif blocks
-# Select device with --cmake-flags -D DEVICE=<fill in device>
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
-if (${DEVICE} MATCHES "raspi4")
-    # -=-=-=-=-
-    # Lists
-    # -=-=-=-=-
-
-    # Add any raspi4 specific packages here
-    # list(APPEND _PACKAGES )
-
-    # -=-=-=-=-
-    # Macros
-    # -=-=-=-=-
-
-    macro(include_directories_macro)
-        include_directories(
-                ${catkin_INCLUDE_DIRS}
-        )
-    endmacro()
-
-    # define an add and link macro
-    # Put items here to build
-    macro(add_and_link_macro)
-        # add_cpp_node_macro(arm_bridge "src/esw/arm_bridge/*")
-    endmacro()
-else ()
-    # -=-=-=-=-
-    # Lists
-    # -=-=-=-=-
-
-    # Add any laptop specific packages here
-    list(APPEND MROVER_PACKAGES
-            tf2_geometry_msgs
-            tf2_ros
-            tf2
-            gazebo_ros
-    )
-
-    # append subdirectories
-    list(APPEND MROVER_CMAKE_INCLUDES
-            starter_project/autonomy/AutonomyStarterProject.cmake
-    )
-
-
-    # -=-=-=-=-
-    # Macros
-    # -=-=-=-=-
-
-    # These packages need to be found individually
-    macro(add_packages_macro)
-        find_package(OpenCV REQUIRED)
-        find_package(gazebo REQUIRED)
-        find_package(Eigen3 REQUIRED)
-        find_package(ZED 2 QUIET)
-        if (ZED_FOUND)
-            # Anything newer than C++17 combined with libstdc++13 is not supported just yet by NVCC (the CUDA compiler)
-            set(CMAKE_CUDA_STANDARD 17)
-            set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-            set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
-            # Jetson Xavier NX is Volta 7.2 architecture
-            # Perception Laptop (A4000, Quadro version of RTX 3080) is Ampere 8.6 architecture
-            set(CMAKE_CUDA_ARCHITECTURES 72 86)
-            enable_language(CUDA)
-        endif ()
-    endmacro()
-
-    # define an add and link macro
-    # Put items here to build
-    macro(add_and_link_macro)
-        add_cpp_nodelet_macro(tag_detector_nodelet src/perception/tag_detector/*.cpp src/perception/tag_detector)
-        target_precompile_headers(tag_detector_nodelet PRIVATE src/perception/tag_detector/pch.hpp)
-        target_link_libraries(tag_detector_nodelet PRIVATE opencv_core opencv_objdetect opencv_aruco opencv_imgproc lie)
-
-        add_cpp_library_macro(lie src/util/lie/*.cpp src/util/lie)
-
-        add_cpp_interface_library_macro(moteus deps/moteus/lib/cpp/mjbots)
-        
-        add_gazebo_plugin_macro(differential_drive_plugin_6w src/simulator/differential_drive_6w.cpp src)
-
-        add_gazebo_plugin_macro(kinect_plugin src/simulator/gazebo_ros_openni_kinect.cpp src/simulator)
-        target_link_libraries(kinect_plugin PRIVATE gazebo_ros_camera_utils DepthCameraPlugin Eigen3::Eigen)
-        set_target_properties(kinect_plugin PROPERTIES CXX_CLANG_TIDY "")
-
-        add_cpp_node_macro(sim_arm_bridge src/simulator/arm_bridge/*.cpp)
-
-        if (ZED_FOUND)
-            add_cpp_nodelet_macro(zed_nodelet src/perception/zed_wrapper/*.c* src/perception/zed_wrapper)
-            target_precompile_headers(zed_nodelet PRIVATE src/perception/zed_wrapper/pch.hpp)
-            target_include_directories(zed_nodelet SYSTEM PRIVATE ${ZED_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
-            target_link_libraries(zed_nodelet PRIVATE ${ZED_LIBRARIES} ${OpenCV_LIBRARIES} ${SPECIAL_OS_LIBS} lie)
-            target_compile_definitions(zed_nodelet PRIVATE
-                    MROVER_IS_NODELET # Generate code relevant to nodelet
-                    ALLOW_BUILD_DEBUG # Ignore ZED warnings about Debug mode
-                    __CUDA_INCLUDE_COMPILER_INTERNAL_HEADERS__ # Eigen includes some files it should not, ignore
-            )
-        endif ()
-    endmacro()
+find_package(OpenCV REQUIRED)
+find_package(ZED 2 QUIET)
+find_package(gazebo REQUIRED)
+find_package(Eigen3 REQUIRED)
+if (ZED_FOUND)
+    # Anything newer than C++17 combined with libstdc++13 is not supported just yet by NVCC (the CUDA compiler)
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
+    set(CMAKE_CUDA_FLAGS "--diag-suppress 108,68")
+    # Jetson Xavier NX is Volta 7.2 architecture
+    # Perception Laptop (A4000, Quadro version of RTX 3080) is Ampere 8.6 architecture
+    set(CMAKE_CUDA_ARCHITECTURES 72 86)
+    enable_language(CUDA)
 endif ()
 
-
-# 3. Find Packages
 find_package(
         catkin REQUIRED COMPONENTS
-        ${MROVER_PACKAGES}
+        ${MROVER_ROS_DEPENDENCIES}
 )
 
-if (COMMAND add_packages_macro)
-    add_packages_macro()
-endif ()
-
-
-# 4. Python module support
 catkin_python_setup()
 
-
-# 4.5. CMake includes before message declarations
-foreach (CMAKE_INCLUDE ${MROVER_CMAKE_INCLUDES})
-    include(${CMAKE_INCLUDE})
+foreach (MROVER_CMAKE_INCLUDE ${MROVER_CMAKE_INCLUDES})
+    include(${MROVER_CMAKE_INCLUDE})
 endforeach ()
 
+### ======== ###
+### Messages ###
+### ======== ###
 
-# 5. Message Generators (add_xxx)
 add_message_files(
         FILES
         ${MROVER_MESSAGE_FILES}
@@ -296,38 +174,77 @@ add_service_files(
         ${MROVER_SERVICE_FILES}
 )
 
-
-# 6. Invoke messages (generate_messages)
 generate_messages(
         DEPENDENCIES
-        ${MROVER_ROS_MESSAGES}
+        ${MROVER_MESSAGE_DEPENDENCIES}
 )
 
 generate_dynamic_reconfigure_options(
         ${MROVER_PARAMETERS}
 )
 
+catkin_package()
 
-# 7. Specify package build info export (catkin_package)
-catkin_package(
-        CATKIN_DEPENDS
-        ${MROVER_CATKIN_PACKAGES}
+### ======= ###
+### Targets ###
+### ======= ###
+
+# Please browse the "Macros" section before adding anything here
+# Lots of custom macros have been added to make adding new targets easier
+
+## Libraries
+
+mrover_add_header_only_library(moteus deps/moteus/lib/cpp/mjbots)
+mrover_add_library(lie src/util/lie/*.cpp src/util/lie)
+
+## ESW
+
+mrover_add_node(sim_arm_bridge src/simulator/arm_bridge/*.cpp)
+
+## Perception
+
+mrover_add_nodelet(tag_detector src/perception/tag_detector/*.cpp src/perception/tag_detector src/perception/tag_detector/pch.hpp)
+mrover_nodelet_link_libraries(tag_detector opencv_core opencv_objdetect opencv_aruco opencv_imgproc tbb lie)
+
+if (ZED_FOUND)
+    mrover_add_nodelet(zed src/perception/zed_wrapper/*.c* src/perception/zed_wrapper src/perception/zed_wrapper/pch.hpp)
+    mrover_nodelet_include_directories(zed ${ZED_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
+    mrover_nodelet_link_libraries(zed ${ZED_LIBRARIES} ${SPECIAL_OS_LIBS} lie)
+    mrover_nodelet_defines(zed
+            ALLOW_BUILD_DEBUG # Ignore ZED warnings about Debug mode
+            __CUDA_INCLUDE_COMPILER_INTERNAL_HEADERS__ # Eigen includes some files it should not, ignore
+    )
+endif ()
+
+## Simulator
+
+mrover_add_gazebo_plugin(differential_drive_plugin_6w src/simulator/differential_drive_6w.cpp src)
+
+mrover_add_gazebo_plugin(kinect_plugin src/simulator/gazebo_ros_openni_kinect.cpp src/simulator)
+target_link_libraries(kinect_plugin PRIVATE gazebo_ros_camera_utils DepthCameraPlugin Eigen3::Eigen)
+set_target_properties(kinect_plugin PROPERTIES CXX_CLANG_TIDY "")
+
+### ======= ###
+### Testing ###
+### ======= ###
+
+# Add C++ unit tests
+catkin_add_gtest(example-cpp-test test/example/cpp_test.cpp)
+
+# Python unit tests
+catkin_add_nosetests(test/navigation/drive_test.py)
+catkin_add_nosetests(test/teleop/teleop_test.py)
+catkin_add_nosetests(test/util/SE3_test.py)
+catkin_add_nosetests(test/util/SO3_test.py)
+
+# Integration tests (python and c++)
+find_package(rostest REQUIRED)
+add_rostest(test/example/basic_integration_test.test)
+add_rostest(test/integration/integration.test)
+add_rostest(test/util/SE3_tf_test.test)
+
+## Install
+
+install(DIRECTORY launch/
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
-
-
-if (COMMAND add_and_link_macro)
-    add_and_link_macro()
-endif ()
-
-
-# 9. Tests to build
-if (COMMAND add_tests_macro)
-    add_tests_macro()
-endif ()
-
-
-# 10. Install rules
-install_launch_macro()
-if (COMMAND additional_install_macro)
-    additional_install_macro()
-endif ()


### PR DESCRIPTION
- Shorter overall
- Automatically add all messages in `./msg` and services in `./srv`
- Automatically create a node for corresponding nodelets. This makes debugging way easier @alisonryckman since the node can be launched on its own instead of in a nodelet manager.
- Remove support for raspi since we are no longer using it