### PR TITLE
Refactor enable auton message to 'AutonCommand'

### DIFF
--- a/msg/AutonCommand.msg
+++ b/msg/AutonCommand.msg
@@ -1,0 +1,2 @@
+GPSWaypoint[] waypoints
+bool is_enabled

--- a/msg/GPSWaypoint.msg
+++ b/msg/GPSWaypoint.msg
@@ -1,4 +1,4 @@
 float64 latitude_degrees
 float64 longitude_degrees
 WaypointType type
-int32 tag_id
+int32 id

--- a/msg/GPSWaypoint.msg
+++ b/msg/GPSWaypoint.msg
@@ -1,4 +1,4 @@
 float64 latitude_degrees
 float64 longitude_degrees
 WaypointType type
-int32 id
+int32 tag_id

--- a/msg/WaypointType.msg
+++ b/msg/WaypointType.msg
@@ -1,3 +1,5 @@
 int32 NO_SEARCH = 0
 int32 POST = 1
+int32 MALLET = 2
+int32 WATER_BOTTLE = 3
 int32 val

--- a/scripts/debug_disable_auton.py
+++ b/scripts/debug_disable_auton.py
@@ -3,8 +3,7 @@
 import numpy as np
 
 import rospy
-from mrover.msg import EnableAuton
-from mrover.srv import PublishEnableAuton
+from mrover.msg import AutonCommand
 from util.course_publish_helpers import publish_waypoints
 
 
@@ -17,10 +16,7 @@ and without fiducials and these will get published to nav
 
 if __name__ == "__main__":
     rospy.init_node("debug_disable_auton")
-    rospy.wait_for_service("enable_auton")
-    try:
-        publish_enable = rospy.ServiceProxy("enable_auton", PublishEnableAuton)
-        msg = EnableAuton([], False)
-        publish_enable(msg)
-    except rospy.ServiceException as e:
-        print(f"Service call failed: {e}")
+    publish_enable = rospy.Publisher("auton/command", AutonCommand, queue_size=1)
+    msg = AutonCommand([], False)
+    while 1:
+        publish_enable.publish(msg)

--- a/src/navigation/context.py
+++ b/src/navigation/context.py
@@ -176,9 +176,7 @@ def convert_gps_to_cartesian(waypoint: GPSWaypoint) -> Tuple[Waypoint, SE3]:
     # navigation algorithmns currently require all coordinates to have zero as the z coordinate
     odom[2] = 0
 
-    return Waypoint(fiducial_id=waypoint.tag_id, tf_id=f"course{waypoint.tag_id}", type=waypoint.type), SE3(
-        position=odom
-    )
+    return Waypoint(fiducial_id=waypoint.id, tf_id=f"course{waypoint.id}", type=waypoint.type), SE3(position=odom)
 
 
 def convert_cartesian_to_gps(coordinate: np.ndarray) -> GPSWaypoint:

--- a/src/util/course_publish_helpers.py
+++ b/src/util/course_publish_helpers.py
@@ -1,4 +1,5 @@
 import rospy
+import time
 
 # from mrover.srv import PublishEnableAuton
 from mrover.msg import GPSWaypoint, Waypoint, AutonCommand
@@ -24,7 +25,11 @@ REF_LON = rospy.get_param("gps_linearization/reference_point_longitude")
 def publish_waypoints(waypoints):
     publish_enable = rospy.Publisher("auton/command", AutonCommand, queue_size=1)
     msg = AutonCommand(waypoints, True)
+    rospy.loginfo("about to publish")
+    time.sleep(1)
     publish_enable.publish(msg)
+    rospy.loginfo("published")
+    rospy.spin()
 
 
 def convert_waypoint_to_gps(waypoint_pose_pair: Tuple[Waypoint, SE3]) -> GPSWaypoint:

--- a/src/util/course_publish_helpers.py
+++ b/src/util/course_publish_helpers.py
@@ -14,11 +14,8 @@ REF_LON = rospy.get_param("gps_linearization/reference_point_longitude")
 def publish_waypoints(waypoints):
     publish_enable = rospy.Publisher("auton/command", AutonCommand, queue_size=1)
     msg = AutonCommand(waypoints, True)
-    rospy.loginfo("about to publish")
-    time.sleep(1)
-    publish_enable.publish(msg)
-    rospy.loginfo("published")
-    rospy.spin()
+    while 1:
+        publish_enable.publish(msg)
 
 
 def convert_waypoint_to_gps(waypoint_pose_pair: Tuple[Waypoint, SE3]) -> GPSWaypoint:

--- a/src/util/course_publish_helpers.py
+++ b/src/util/course_publish_helpers.py
@@ -1,7 +1,6 @@
 import rospy
 import time
 
-# from mrover.srv import PublishEnableAuton
 from mrover.msg import GPSWaypoint, Waypoint, AutonCommand
 from typing import Tuple
 from util.SE3 import SE3
@@ -10,16 +9,6 @@ import pymap3d
 
 REF_LAT = rospy.get_param("gps_linearization/reference_point_latitude")
 REF_LON = rospy.get_param("gps_linearization/reference_point_longitude")
-
-
-# def publish_waypoints_old(waypoints):
-#     rospy.wait_for_service("enable_auton")
-#     try:
-#         publish_enable = rospy.ServiceProxy("enable_auton", PublishEnableAuton)
-#         msg = EnableAuton(waypoints, True)
-#         publish_enable(msg)
-#     except rospy.ServiceException as e:
-#         print(f"Service call failed: {e}")
 
 
 def publish_waypoints(waypoints):

--- a/src/util/course_publish_helpers.py
+++ b/src/util/course_publish_helpers.py
@@ -1,6 +1,7 @@
 import rospy
-from mrover.srv import PublishEnableAuton
-from mrover.msg import EnableAuton, GPSWaypoint, Waypoint
+
+# from mrover.srv import PublishEnableAuton
+from mrover.msg import GPSWaypoint, Waypoint, AutonCommand
 from typing import Tuple
 from util.SE3 import SE3
 import pymap3d
@@ -10,14 +11,20 @@ REF_LAT = rospy.get_param("gps_linearization/reference_point_latitude")
 REF_LON = rospy.get_param("gps_linearization/reference_point_longitude")
 
 
+# def publish_waypoints_old(waypoints):
+#     rospy.wait_for_service("enable_auton")
+#     try:
+#         publish_enable = rospy.ServiceProxy("enable_auton", PublishEnableAuton)
+#         msg = EnableAuton(waypoints, True)
+#         publish_enable(msg)
+#     except rospy.ServiceException as e:
+#         print(f"Service call failed: {e}")
+
+
 def publish_waypoints(waypoints):
-    rospy.wait_for_service("enable_auton")
-    try:
-        publish_enable = rospy.ServiceProxy("enable_auton", PublishEnableAuton)
-        msg = EnableAuton(waypoints, True)
-        publish_enable(msg)
-    except rospy.ServiceException as e:
-        print(f"Service call failed: {e}")
+    publish_enable = rospy.Publisher("auton/command", AutonCommand, queue_size=1)
+    msg = AutonCommand(waypoints, True)
+    publish_enable.publish(msg)
 
 
 def convert_waypoint_to_gps(waypoint_pose_pair: Tuple[Waypoint, SE3]) -> GPSWaypoint:


### PR DESCRIPTION
## Summary
Closes #543

- I created a new file AutonCommand.msg and added the new types to WaypointType.msg (MALLET and WATER_BOTTLE). 
- I changed context.py by adding a subscriber to the "auton/command" topic in Context and changed the functions that used the EnableAuton message to use the AutonCommand message. 
- I changed course_publish_helpers.py to use a publisher instead of a service so I could test the change with debug_course_publisher.py and debug_enable_auton.py.

### Did you add documentation to the wiki?
No 

## How was this code tested? 
- I used auton_sim.launch and ran the debug_course_publisher.py to verify it worked the same way as it did on the master branch (the old code). This meant that it receives the message full of waypoints and uses it to set the course and start driving to the first waypoint
- I used auton_sim.launch and ran debug_course_publisher.py to first set the waypoints in the course. Then I ran debug_enable_auton.py to change the waypoints to see if the message was marked as different in the auton_command_callback (which then causes the course to be updated). Then I ran debug_disable_auton.py to change the is_enabled bool to once again see if the message was marked as different in the auton_command_callback. I printed whenever a change was detected (otherwise it meant the message was ignored if it was the same, which is the behavior we want).

### Did you test this in sim? 
Yes

### Did you test this on the rover?
No

### Did you add unit tests? 
I changed course_publish_helpers.py so that debug_course_publisher.py works with the new message. But I don’t know if it would be worth it to change debug_service.py or just delete it. After we fix that, we could also delete the EnableAuton.msg since AutonCommand.msg replaces it.