### PR TITLE
Remove tf_id from Waypoint.msg

### DIFF
--- a/msg/Waypoint.msg
+++ b/msg/Waypoint.msg
@@ -1,3 +1,2 @@
 uint8 tag_id
-string tf_id
 WaypointType type

--- a/scripts/debug_course_publisher.py
+++ b/scripts/debug_course_publisher.py
@@ -20,15 +20,15 @@ if __name__ == "__main__":
 
     waypoints = [
         (
-            Waypoint(tag_id=2, tf_id="course0", type=WaypointType(val=WaypointType.NO_SEARCH)),
+            Waypoint(tag_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
             SE3(position=np.array([4, 4, 0])),
         ),
         (
-            Waypoint(tag_id=0, tf_id="course1", type=WaypointType(val=WaypointType.POST)),
+            Waypoint(tag_id=0, type=WaypointType(val=WaypointType.POST)),
             SE3(position=np.array([-2, -2, 0])),
         ),
         (
-            Waypoint(tag_id=1, tf_id="course2", type=WaypointType(val=WaypointType.POST)),
+            Waypoint(tag_id=1, type=WaypointType(val=WaypointType.POST)),
             SE3(position=np.array([11, -10, 0])),
         ),
     ]

--- a/scripts/test_ekf.py
+++ b/scripts/test_ekf.py
@@ -14,46 +14,46 @@ from util.SE3 import SE3
 
 SQUARE_PATH = [
     (
-        Waypoint(fiducial_id=0, tf_id="course0", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([3, 3, 0])),
     ),
     (
-        Waypoint(fiducial_id=1, tf_id="course1", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=1, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([0, 6, 0])),
     ),
     (
-        Waypoint(fiducial_id=2, tf_id="course2", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=2, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([-3, 3, 0])),
     ),
     (
-        Waypoint(fiducial_id=3, tf_id="course3", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=3, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([0, 0, 0])),
     ),
 ]
 ANGLE_PATH = [
     (
-        Waypoint(fiducial_id=0, tf_id="course0", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([6, 0, 0])),
     ),
     (
-        Waypoint(fiducial_id=3, tf_id="course3", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=3, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([10, 9, 0])),
     ),
 ]
 LINE_PATH = [
     (
-        Waypoint(fiducial_id=0, tf_id="course0", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([7, 3.7, 0])),
     ),
 ]
 
 SIM_LINE_PATH = [
     (
-        Waypoint(fiducial_id=0, tf_id="course1", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([-3.2, 1.4, 0])),
     ),
     (
-        Waypoint(fiducial_id=0, tf_id="course0", type=WaypointType(val=WaypointType.NO_SEARCH)),
+        Waypoint(fiducial_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
         SE3(position=np.array([-1, 5, 0])),
     ),
 ]

--- a/src/navigation/context.py
+++ b/src/navigation/context.py
@@ -117,7 +117,7 @@ class Course:
         """
         Gets the pose of the waypoint with the given index
         """
-        waypoint_frame = self.course_data.waypoints[wp_idx].tf_id
+        waypoint_frame = f"course{wp_idx}"
         return SE3.from_tf_tree(self.ctx.tf_buffer, parent_frame="map", child_frame=waypoint_frame)
 
     def current_waypoint_pose(self) -> SE3:
@@ -154,9 +154,9 @@ class Course:
 
 def setup_course(ctx: Context, waypoints: List[Tuple[Waypoint, SE3]]) -> Course:
     all_waypoint_info = []
-    for waypoint_info, pose in waypoints:
+    for wp_idx, (waypoint_info, pose) in enumerate(waypoints):
         all_waypoint_info.append(waypoint_info)
-        pose.publish_to_tf_tree(tf_broadcaster, "map", waypoint_info.tf_id)
+        pose.publish_to_tf_tree(tf_broadcaster, "map", f"course{wp_idx}")
     # make the course out of just the pure waypoint objects which is the 0th elt in the tuple
     return Course(ctx=ctx, course_data=mrover.msg.Course([waypoint[0] for waypoint in waypoints]))
 
@@ -176,7 +176,7 @@ def convert_gps_to_cartesian(waypoint: GPSWaypoint) -> Tuple[Waypoint, SE3]:
     # navigation algorithms currently require all coordinates to have zero as the z coordinate
     odom[2] = 0
 
-    return Waypoint(tag_id=waypoint.tag_id, tf_id=f"course{waypoint.tag_id}", type=waypoint.type), SE3(position=odom)
+    return Waypoint(tag_id=waypoint.tag_id, type=waypoint.type), SE3(position=odom)
 
 
 def convert_cartesian_to_gps(coordinate: np.ndarray) -> GPSWaypoint:

--- a/test/integration/integration.py
+++ b/test/integration/integration.py
@@ -26,7 +26,7 @@ class TestIntegration(unittest.TestCase):
         waypoint_in_world = SE3(position=np.array([-5.5, -5.5, 0.0]))
         waypoints = [
             (
-                Waypoint(tag_id=0, tf_id="course0", type=WaypointType(val=WaypointType.NO_SEARCH)),
+                Waypoint(tag_id=0, type=WaypointType(val=WaypointType.NO_SEARCH)),
                 waypoint_in_world,
             ),
         ]


### PR DESCRIPTION
## Summary
What features did you add, bugs did you fix, etc? 
Fixes the issue where tf_id is being created based on the tag_id. Now the tf link is based on the current index in the waypoints list instead, so there is no need for tf_id anymore in Waypoint.msg.

### Did you add documentation to the wiki?
No

## How was this code tested? 
Ran debug_course_publisher.py with tag_id set to 0 for two of the waypoints in the waypoint list. Before the fix, one of the waypoints would be ignored because both waypoints would be published to the tf tree as "course0". After the fix, all waypoints are visited and behavior is as expected.

### Did you test this in sim? 
Yes

### Did you test this on the rover?
No

### Did you add unit tests? 
No, but fixed old test files
