### PR TITLE
Localization in integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           # This makes sure that $GITHUB_WORKSPACE is the catkin workspace path
           path: "src/mrover"
       - name: Ensure Python Requirements
-        run: . /home/mrover/catkin_ws/src/mrover/venv/bin/activate && pip install -e "$GITHUB_WORKSPACE/src/mrover[dev]"
+        run: . /home/mrover/catkin_ws/src/mrover/venv/bin/activate && pip install --no-cache-dir -e "$GITHUB_WORKSPACE/src/mrover[dev]"
       - name: Style Check
         run: . /home/mrover/catkin_ws/src/mrover/venv/bin/activate && cd $GITHUB_WORKSPACE/src/mrover/ && ./style.sh
       - name: Update ROS APT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "empy==3.3.4",
     "numpy==1.26.3",
     "pandas==2.2.0",
-    "PyArrow==1.26.3",
+    "pyarrow==15.0.0",
     "shapely==2.0.1",
     "pyserial==3.5",
     "moteus==0.3.59",


### PR DESCRIPTION
## Summary
Closes #168 

What features did you add, bugs did you fix, etc? 
Instead of just checking the localization estimate against the target position in the integration test, it now uses the rover's ground truth pose. It also separately makes sure the estimation error remained below a certain threshold.

### Did you add documentation to the wiki?
No

## How was this code tested? 
The integration test was run with varying error thresholds.

### Did you test this in sim? 
Yes

### Did you test this on the rover?
No

### Did you add unit tests? 
No
